### PR TITLE
feat(sharelinks): implement scanner-tolerant magic link email verific…

### DIFF
--- a/backend/bdd/step_definitions/test_share_link_email_protection.py
+++ b/backend/bdd/step_definitions/test_share_link_email_protection.py
@@ -128,6 +128,14 @@ def verification_token(share_link_context, email):
 def access_with_token(public_client, share_link_context, verification_token):
     share_link = share_link_context['share_link']
     url = f'/api/v1/links/{share_link.slug}/view-data/?accessToken={verification_token.token}'
+    res_get = public_client.get(url)
+    assert res_get.status_code == 401
+    assert res_get.json()['requiresConfirmation'] is True
+
+    confirm_url = f'/api/v1/links/{share_link.slug}/verify-access-token/confirm/'
+    res_post = public_client.post(confirm_url, {'token': verification_token.token})
+    assert res_post.status_code == 200
+
     return public_client.get(url)
 
 

--- a/backend/sharelinks/urls.py
+++ b/backend/sharelinks/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('links/<slug:slug>/public-meta/', views.ShareLinkPublicMetaView.as_view(), name='share-link-public-meta'),
     path('links/<slug:slug>/verify-password/', views.ShareLinkVerifyPasswordView.as_view(), name='share-link-verify-password'),
     path('links/<slug:slug>/request-access/', views.ShareLinkRequestAccessView.as_view(), name='share-link-request-access'),
+    path('links/<slug:slug>/verify-access-token/confirm/', views.ShareLinkConfirmAccessView.as_view(), name='share-link-confirm-access'),
     path('links/<slug:slug>/view-data/', views.ShareLinkViewDataView.as_view(), name='share-link-view-data'),
     path('links/<slug:slug>/qna-summary/', views.ShareLinkQnASummaryView.as_view(), name='share-link-qna-summary'),
     path('links/<slug:slug>/qna-threads/', views.ShareLinkQnAThreadListCreateView.as_view(), name='share-link-qna-threads'),

--- a/backend/sharelinks/views.py
+++ b/backend/sharelinks/views.py
@@ -537,20 +537,19 @@ class ShareLinkViewDataView(APIView):
                 with transaction.atomic():
                     verification = EmailVerificationToken.objects.select_for_update().get(token=access_token)
                     if not verification.is_expired() and verification.share_link == link:
-                        # Magic link authorizes both steps.
-                        authorized_links = request.session.get('authorized_share_links', {})
-                        authorized_links[str(link.id)] = {
-                            'password_verified': True,
-                            'email_verified': True,
-                            'viewer_email': verification.email,
+                        # Store the pending verification in request.session instead of authorizing/consuming on GET
+                        pending_verifications = request.session.get('pending_email_verifications', {})
+                        pending_verifications[access_token] = {
+                            'email': verification.email,
+                            'link_id': str(link.id)
                         }
-                        request.session['authorized_share_links'] = authorized_links
-                        _dispatch_automation_event(
-                            link,
-                            'email_identified',
-                            {'viewer_email': verification.email},
-                        )
-                        verification.delete()
+                        request.session['pending_email_verifications'] = pending_verifications
+                        return Response({
+                            "message": "Verification token is valid. Please confirm access.",
+                            "protectionType": "email",
+                            "requiresConfirmation": True,
+                            "emailToConfirm": verification.email,
+                        }, status=status.HTTP_401_UNAUTHORIZED)
             except EmailVerificationToken.DoesNotExist:
                 logger.debug(f"Invalid or expired access token used for share link {slug}: {access_token}")
                 pass  # Token is invalid, proceed with normal checks.
@@ -1518,7 +1517,6 @@ class ShareLinkRequestAccessView(APIView):
                 settings.SITE_DOMAIN,
                 f"/view/{link.slug}?accessToken={verification.token}"
             )
-            
             # Send email
             try:
                 target_name = link.document.name if link.document else link.dataroom.name
@@ -1550,6 +1548,70 @@ class ShareLinkRequestAccessView(APIView):
                 {"message": "Verification link sent. Please check your email to continue.", "verification_required": True},
                 status=status.HTTP_200_OK
             )
+
+
+class ShareLinkConfirmAccessView(APIView):
+    """
+    Finalizes the email verification using a magic link access token.
+    This sets the session authorization and deletes the token.
+    """
+    permission_classes = [permissions.AllowAny]
+
+    @extend_schema(
+        request=dict,
+        responses={200: dict, 400: dict, 404: dict},
+    )
+    def post(self, request, slug, *args, **kwargs):
+        token = request.data.get('token')
+        if not token:
+            return Response({"message": "Token is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            link = _get_active_share_link(slug)
+        except NotFound as e:
+            return Response({"message": e.detail}, status=status.HTTP_404_NOT_FOUND)
+
+        # Retrieve the pending verification details from session to bind it to the same browser context
+        pending_verifications = request.session.get('pending_email_verifications', {})
+        pending = pending_verifications.get(token)
+        if not pending or pending.get('link_id') != str(link.id):
+            return Response(
+                {"message": "Verification context mismatch. Please request a new verification link."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            with transaction.atomic():
+                verification = EmailVerificationToken.objects.select_for_update().get(token=token)
+                if verification.is_expired() or verification.share_link != link:
+                    return Response({"message": "The verification link has expired or is invalid."}, status=status.HTTP_400_BAD_REQUEST)
+
+                # Authorize the session
+                authorized_links = request.session.get('authorized_share_links', {})
+                authorized_links[str(link.id)] = {
+                    'password_verified': True,
+                    'email_verified': True,
+                    'viewer_email': verification.email,
+                }
+                request.session['authorized_share_links'] = authorized_links
+                
+                _dispatch_automation_event(
+                    link,
+                    'email_identified',
+                    {'viewer_email': verification.email},
+                )
+                
+                # Delete the token to consume it
+                verification.delete()
+                
+                # Clear the pending verification in the session
+                if token in pending_verifications:
+                    del pending_verifications[token]
+                    request.session['pending_email_verifications'] = pending_verifications
+
+                return Response({"message": "Access granted successfully."}, status=status.HTTP_200_OK)
+        except EmailVerificationToken.DoesNotExist:
+            return Response({"message": "The verification link has already been used or is invalid."}, status=status.HTTP_400_BAD_REQUEST)
 
 
 def _calculate_watermark_grid_params(page_width, page_height, rotated_tile_width, rotated_tile_height):

--- a/backend/tests/sharelinks/test_views.py
+++ b/backend/tests/sharelinks/test_views.py
@@ -1584,7 +1584,8 @@ class TestShareLinkEmailProtection:
 
     def test_view_data_with_valid_access_token(self, public_client, share_link_requires_email_verification):
         """
-        Using a valid access token from an email magic link should grant access.
+        Using a valid access token from an email magic link should NOT grant access immediately on GET.
+        It should return 401 requiring confirmation, then after POST confirm, access is granted.
         """
         # Step 1: Create a token manually (as if an email was sent)
         token = EmailVerificationToken.objects.create(
@@ -1593,19 +1594,71 @@ class TestShareLinkEmailProtection:
         )
         assert EmailVerificationToken.objects.count() == 1
 
-        # Step 2: Access the data with the token
+        # Step 2: Access the data with the token via GET - should require confirmation (HTTP 401)
         view_data_url = f'/api/v1/links/{share_link_requires_email_verification.slug}/view-data/?accessToken={token.token}'
         response_view = public_client.get(view_data_url)
 
-        assert response_view.status_code == status.HTTP_200_OK
-        assert 'id' in response_view.json()
+        assert response_view.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response_view.json()['requiresConfirmation'] is True
+        assert response_view.json()['emailToConfirm'] == 'viewer@example.com'
+        
+        # Token is still in DB (not consumed by GET)
+        assert EmailVerificationToken.objects.count() == 1
 
-        # Step 3: Verify the token was single-use and deleted
+        # Step 3: Confirm the token via POST
+        confirm_url = f'/api/v1/links/{share_link_requires_email_verification.slug}/verify-access-token/confirm/'
+        response_confirm = public_client.post(confirm_url, {'token': token.token}, format='json')
+        assert response_confirm.status_code == status.HTTP_200_OK
+
+        # Token is now consumed/deleted
         assert EmailVerificationToken.objects.count() == 0
 
         # Step 4: Subsequent access without the token should be allowed due to session
         response_view_2 = public_client.get(f'/api/v1/links/{share_link_requires_email_verification.slug}/view-data/')
         assert response_view_2.status_code == status.HTTP_200_OK
+
+    def test_confirm_access_token_mismatch_fails(self, public_client, share_link_requires_email_verification):
+        """Confirming a token without a valid session context or mismatched token fails."""
+        token = EmailVerificationToken.objects.create(
+            share_link=share_link_requires_email_verification,
+            email='viewer@example.com'
+        )
+        confirm_url = f'/api/v1/links/{share_link_requires_email_verification.slug}/verify-access-token/confirm/'
+        response_confirm = public_client.post(confirm_url, {'token': token.token}, format='json')
+        
+        # Fails with 400 because GET view-data was never called to set the pending token in this session
+        assert response_confirm.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'context mismatch' in response_confirm.json()['message']
+
+    def test_confirm_access_multiple_tabs_no_collision(self, public_client, share_link_requires_email_verification):
+        """Opening multiple verification links in different tabs should not overwrite pending verifications."""
+        token_a = EmailVerificationToken.objects.create(
+            share_link=share_link_requires_email_verification,
+            email='viewer_a@example.com'
+        )
+        token_b = EmailVerificationToken.objects.create(
+            share_link=share_link_requires_email_verification,
+            email='viewer_b@example.com'
+        )
+
+        # GET request for Token A (simulating opening Tab A)
+        view_data_url_a = f'/api/v1/links/{share_link_requires_email_verification.slug}/view-data/?accessToken={token_a.token}'
+        response_a = public_client.get(view_data_url_a)
+        assert response_a.status_code == status.HTTP_401_UNAUTHORIZED
+
+        # GET request for Token B (simulating opening Tab B)
+        view_data_url_b = f'/api/v1/links/{share_link_requires_email_verification.slug}/view-data/?accessToken={token_b.token}'
+        response_b = public_client.get(view_data_url_b)
+        assert response_b.status_code == status.HTTP_401_UNAUTHORIZED
+
+        # Confirm Token A via POST (confirming Tab A)
+        confirm_url = f'/api/v1/links/{share_link_requires_email_verification.slug}/verify-access-token/confirm/'
+        response_confirm_a = public_client.post(confirm_url, {'token': token_a.token}, format='json')
+        assert response_confirm_a.status_code == status.HTTP_200_OK
+
+        # Confirm Token B via POST (confirming Tab B)
+        response_confirm_b = public_client.post(confirm_url, {'token': token_b.token}, format='json')
+        assert response_confirm_b.status_code == status.HTTP_200_OK
 
     def test_view_data_with_expired_access_token(self, public_client, share_link_requires_email_verification):
         """An expired access token should not grant access."""

--- a/docs/features/share-link-verify-pwd-email.md
+++ b/docs/features/share-link-verify-pwd-email.md
@@ -45,6 +45,8 @@ Frontend save behavior:
   - verifies password; sets session authorization
 - `POST /api/v1/links/{slug}/request-access/`
   - handles email step (immediate or magic-link)
+- `POST /api/v1/links/{slug}/verify-access-token/confirm/`
+  - finalizes email verification using magic link token; sets session authorization
 
 Related:
 - `GET /view/{slug}?accessToken=...` (frontend route)
@@ -120,13 +122,18 @@ Then behavior diverges by `requires_email_verification`:
   - `{"message": "...", "verification_required": true}`
 - frontend shows “check your email” state.
 
-When viewer opens magic link:
-- frontend reads `accessToken` query param and calls `view-data`
-- backend validates token and link binding, checks expiry, authorizes session:
-  - `password_verified = true`
-  - `email_verified = true`
-  - `viewer_email = token email`
-- backend deletes token after use
+To prevent secure email gateways/prefetch link scanners from consuming the token before the actual user views the document, the verification relies on a two-step scanner-tolerant flow:
+
+1. **GET Stage (Pending Verification):**
+   - When the magic link is clicked (e.g. by a scanner or viewer), the frontend reads `accessToken` query param and calls `GET /api/v1/links/{slug}/view-data/?accessToken={token}`.
+   - The backend validates the token, but **does not** delete the token or grant full access immediately. Instead, it stores the verification details (consisting of the email and link ID) inside a `pending_email_verifications` dictionary keyed by the token inside the requester's Django session.
+   - The backend returns a `401 Unauthorized` with `requiresConfirmation: true`, `emailToConfirm`, and `protectionType: "email"`.
+   - The frontend `EmailForm` intercepts this response and displays a confirmation screen asking the viewer to confirm access for the specified email.
+
+2. **POST Stage (Access Confirmation & Consumption):**
+   - When the actual viewer clicks "Continue to Document" on the confirmation screen, a `POST` request is sent to `/api/v1/links/{slug}/verify-access-token/confirm/` with the verification token.
+   - The backend checks that the POSTed token matches the pending details in the `pending_email_verifications` dictionary saved in the Django session.
+   - If verified, the backend authorizes the session (`email_verified = true`, `password_verified = true`, `viewer_email = verification.email`), deletes/consumes the token, removes the token key from the session's pending dictionary, and returns `200 OK`.
 
 ## Toggle Effect Summary
 

--- a/frontend/src/components/viewer/EmailForm.jsx
+++ b/frontend/src/components/viewer/EmailForm.jsx
@@ -1,15 +1,23 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { requestShareLinkAccess } from '../../services/api';
+import { requestShareLinkAccess, confirmShareLinkEmailAccess } from '../../services/api';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { Label } from '../ui/Label';
 import { AccessOwnerCard } from './AccessOwnerCard';
 
-export function EmailForm({ slug, onSuccess, publicMeta = null }) {
+export function EmailForm({
+  slug,
+  onSuccess,
+  publicMeta = null,
+  requiresConfirmation = false,
+  emailToConfirm = '',
+  token = '',
+}) {
   const [email, setEmail] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [localRequiresConfirmation, setLocalRequiresConfirmation] = useState(requiresConfirmation);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -29,6 +37,45 @@ export function EmailForm({ slug, onSuccess, publicMeta = null }) {
       setIsLoading(false);
     }
   };
+
+  const handleConfirm = async () => {
+    setIsLoading(true);
+    try {
+      const response = await confirmShareLinkEmailAccess(slug, token);
+      toast.success(response.data.message);
+      onSuccess();
+    } catch (err) {
+      setIsLoading(false);
+    }
+  };
+
+  if (localRequiresConfirmation && emailToConfirm) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+        <div className="w-full max-w-sm rounded-lg bg-white p-8 shadow-md dark:bg-gray-800">
+          <AccessOwnerCard publicMeta={publicMeta} />
+          <h1 className="mb-2 text-left text-2xl font-bold dark:text-white">Verify Your Email</h1>
+          <p className="mb-6 text-left text-sm text-gray-600 dark:text-gray-400">
+            You are verifying access to this document as <strong className="break-all">{emailToConfirm}</strong>.
+          </p>
+          <div className="space-y-4">
+            <Button onClick={handleConfirm} className="w-full" disabled={isLoading}>
+              {isLoading ? 'Verifying...' : 'Continue to Document'}
+            </Button>
+            <div className="text-center">
+              <button
+                onClick={() => setLocalRequiresConfirmation(false)}
+                className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                disabled={isLoading}
+              >
+                Use a different email address
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (hasSubmitted) {
     return (

--- a/frontend/src/pages/ShareLinkViewerPage.jsx
+++ b/frontend/src/pages/ShareLinkViewerPage.jsx
@@ -381,6 +381,9 @@ export function ShareLinkViewerPage() {
         slug={slug}
         onSuccess={() => setRefetchTrigger((c) => c + 1)}
         publicMeta={publicMeta}
+        requiresConfirmation={error?.requiresConfirmation}
+        emailToConfirm={error?.emailToConfirm}
+        token={accessToken}
       />
     );
   }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -280,6 +280,9 @@ export const verifyShareLinkPassword = (slug, password) =>
 export const requestShareLinkAccess = (slug, email) =>
   api.post(`/links/${slug}/request-access/`, { email });
 
+export const confirmShareLinkEmailAccess = (slug, token) =>
+  api.post(`/links/${slug}/verify-access-token/confirm/`, { token });
+
 export const getPublicQnaThreads = (
   slug,
   {

--- a/frontend/src/tests/components/viewer/EmailForm.test.jsx
+++ b/frontend/src/tests/components/viewer/EmailForm.test.jsx
@@ -112,4 +112,71 @@ describe('EmailForm', () => {
     render(<EmailForm slug={slug} onSuccess={mockOnSuccess} publicMeta={null} />);
     expect(screen.getByRole('heading', { name: 'Email Required' })).toBeInTheDocument();
   });
+
+  it('renders the confirmation view when requiresConfirmation is true', () => {
+    render(
+      <EmailForm
+        slug={slug}
+        onSuccess={mockOnSuccess}
+        publicMeta={null}
+        requiresConfirmation={true}
+        emailToConfirm="confirm@example.com"
+        token="my-token-123"
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: /verify your email/i })).toBeInTheDocument();
+    expect(screen.getByText(/you are verifying access to this document as/i)).toBeInTheDocument();
+    expect(screen.getByText('confirm@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue to document/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /use a different email address/i })).toBeInTheDocument();
+  });
+
+  it('calls confirmShareLinkEmailAccess and onSuccess when clicking Continue to Document', async () => {
+    api.confirmShareLinkEmailAccess.mockResolvedValue({
+      data: { message: 'Access granted successfully.' },
+    });
+
+    render(
+      <EmailForm
+        slug={slug}
+        onSuccess={mockOnSuccess}
+        publicMeta={null}
+        requiresConfirmation={true}
+        emailToConfirm="confirm@example.com"
+        token="my-token-123"
+      />
+    );
+
+    const confirmButton = screen.getByRole('button', { name: /continue to document/i });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(api.confirmShareLinkEmailAccess).toHaveBeenCalledWith(slug, 'my-token-123');
+    });
+
+    expect(toast.success).toHaveBeenCalledWith('Access granted successfully.');
+    expect(mockOnSuccess).toHaveBeenCalled();
+  });
+
+  it('switches to normal email input view when clicking Use a different email address', async () => {
+    render(
+      <EmailForm
+        slug={slug}
+        onSuccess={mockOnSuccess}
+        publicMeta={null}
+        requiresConfirmation={true}
+        emailToConfirm="confirm@example.com"
+        token="my-token-123"
+      />
+    );
+
+    expect(screen.queryByLabelText(/email address/i)).not.toBeInTheDocument();
+
+    const switchButton = screen.getByRole('button', { name: /use a different email address/i });
+    fireEvent.click(switchButton);
+
+    expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Corporate email networks use automated security scanners to pre-check links in incoming emails to make sure they are safe before you open them.

Previously, our email verification "magic links" were designed to instantly verify and deactivate themselves the very first time they were opened. Because of this, the automated security scanners were accidentally "using up" the link before it even reached the user's inbox. When the real user clicked the link a few seconds later, the system saw the link as already used, failing the verification and trapping the user in a loop.

### How we resolved it:

We updated the verification process to require a quick, scanner-safe confirmation:

1. Scan-Safe Links: Simply opening the link now only checks if it is valid—it does not activate access or deactivate the link.
2. "Continue" Confirmation Screen: When the user clicks the link, they are now shown a quick confirmation page displaying their email address with a "Continue to Document" button.
3. User-Only Activation: Access is only officially granted and the link deactivated when the user clicks the "Continue" button.

Since automated scanners only inspect links in the background and do not click buttons on web pages, they can no longer accidentally consume or invalidate the verification links.

