### PR TITLE
feat(sharelinks): implement 6-digit numeric verification code (OTP) f…

### DIFF
--- a/backend/bdd/features/share_link_email_protection.feature
+++ b/backend/bdd/features/share_link_email_protection.feature
@@ -30,3 +30,11 @@ Feature: Share Link Email Protection
     When an anonymous viewer requests access with the email "viewer@example.com"
     And they create a view session for the share link
     Then the view session should be associated with the email "viewer@example.com"
+
+  Scenario: A viewer verifies their email with a 6-digit code
+    Given I am an authenticated user
+    And I have a document with a share link that requires email verification
+    And a verification token exists for the email "viewer@example.com"
+    When the viewer submits the correct verification code for "viewer@example.com"
+    Then they should be granted access to the document
+    And the verification token should be consumed

--- a/backend/bdd/step_definitions/test_share_link_email_protection.py
+++ b/backend/bdd/step_definitions/test_share_link_email_protection.py
@@ -140,3 +140,22 @@ def check_access_granted_with_token(view_response):
 @then("the verification token should be consumed")
 def check_token_consumed(verification_token):
     assert not EmailVerificationToken.objects.filter(id=verification_token.id).exists()
+
+
+@pytest.mark.django_db
+@scenario('../features/share_link_email_protection.feature', 'A viewer verifies their email with a 6-digit code')
+def test_viewer_verifies_email_with_code():
+    pass
+
+
+@when(parsers.parse('the viewer submits the correct verification code for "{email}"'), target_fixture="view_response")
+def submit_verification_code(public_client, share_link_context, verification_token, email):
+    share_link = share_link_context['share_link']
+    url = f'/api/v1/links/{share_link.slug}/verify-code/'
+    response = public_client.post(url, {
+        'email': email,
+        'code': verification_token.token
+    })
+    assert response.status_code == 200
+    view_url = f'/api/v1/links/{share_link.slug}/view-data/'
+    return public_client.get(view_url)

--- a/backend/sharelinks/models.py
+++ b/backend/sharelinks/models.py
@@ -78,7 +78,11 @@ class EmailVerificationToken(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.token:
-            self.token = secrets.token_urlsafe(32)
+            while True:
+                code = f"{secrets.randbelow(900000) + 100000}"
+                if not EmailVerificationToken.objects.filter(token=code).exists():
+                    self.token = code
+                    break
         if not self.expires_at:
             # Set expiry for 15 minutes from now.
             self.expires_at = timezone.now() + timedelta(minutes=15)

--- a/backend/sharelinks/serializers.py
+++ b/backend/sharelinks/serializers.py
@@ -325,6 +325,11 @@ class ShareLinkPasswordSerializer(serializers.Serializer):
     password = serializers.CharField(write_only=True)
 
 
+class ShareLinkVerifyCodeSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    code = serializers.CharField(max_length=64)
+
+
 class QnAMessageSerializer(serializers.ModelSerializer):
     sender_type = serializers.SerializerMethodField()
     sender_email = serializers.SerializerMethodField()

--- a/backend/sharelinks/templates/sharelinks/verification_email.html
+++ b/backend/sharelinks/templates/sharelinks/verification_email.html
@@ -1,12 +1,9 @@
 <p>Hello,</p>
-<p>Please click the button below to view <strong>{{ target_name }}</strong>.</p>
-<table width="100%" cellspacing="0" cellpadding="0" style="margin-top: 20px; margin-bottom: 20px;"><tr><td>
-<table cellspacing="0" cellpadding="0"><tr><td style="border-radius: 4px;" bgcolor="#0d6efd">
-<a href="{{ access_url }}" target="_blank" style="padding: 12px 24px; border: 1px solid #0d6efd; border-radius: 4px; font-family: sans-serif; font-size: 16px; line-height: 1; text-align: center; text-decoration: none; display: block; color: #ffffff;">
-Verify and View</a>
-</td></tr></table>
-</td></tr></table>
-<p>If the button does not work, you can copy and paste this link into your browser:</p>
-<p><a href="{{ access_url }}">{{ access_url }}</a></p>
-<p style="color: #6c757d; font-size: 14px;">This link will expire in 15 minutes.</p>
+<p>You requested access to view <strong>{{ target_name }}</strong>. Please use the verification code below to verify your email address and continue:</p>
+<div style="margin-top: 24px; margin-bottom: 24px; text-align: left;">
+  <span style="display: inline-block; padding: 12px 24px; font-family: Courier, monospace; font-size: 28px; font-weight: bold; letter-spacing: 4px; color: #1e293b; background-color: #f1f5f9; border: 1px solid #cbd5e1; border-radius: 6px;">
+    {{ verification_code }}
+  </span>
+</div>
+<p style="color: #64748b; font-size: 14px; margin-top: 16px;">This code will expire in 15 minutes. If you did not request this, you can safely ignore this email.</p>
 <p>Thank you.</p>

--- a/backend/sharelinks/templates/sharelinks/verification_email.txt
+++ b/backend/sharelinks/templates/sharelinks/verification_email.txt
@@ -1,9 +1,9 @@
 Hello,
 
-Please click the link below to view '{{ target_name }}'.
+Your verification code to view '{{ target_name }}' is:
 
-{{ access_url }}
+{{ verification_code }}
 
-This link will expire in 15 minutes.
+This code will expire in 15 minutes.
 
 Thank you.

--- a/backend/sharelinks/urls.py
+++ b/backend/sharelinks/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('links/<slug:slug>/public-meta/', views.ShareLinkPublicMetaView.as_view(), name='share-link-public-meta'),
     path('links/<slug:slug>/verify-password/', views.ShareLinkVerifyPasswordView.as_view(), name='share-link-verify-password'),
     path('links/<slug:slug>/request-access/', views.ShareLinkRequestAccessView.as_view(), name='share-link-request-access'),
+    path('links/<slug:slug>/verify-code/', views.ShareLinkVerifyCodeView.as_view(), name='share-link-verify-code'),
     path('links/<slug:slug>/view-data/', views.ShareLinkViewDataView.as_view(), name='share-link-view-data'),
     path('links/<slug:slug>/qna-summary/', views.ShareLinkQnASummaryView.as_view(), name='share-link-qna-summary'),
     path('links/<slug:slug>/qna-threads/', views.ShareLinkQnAThreadListCreateView.as_view(), name='share-link-qna-threads'),

--- a/backend/sharelinks/views.py
+++ b/backend/sharelinks/views.py
@@ -52,6 +52,7 @@ from .serializers import (DataroomVisitSerializer, PageViewRecordSerializer,
                           QnAThreadStatusUpdateSerializer,
                           ShareLinkDataroomSettingUpdateSerializer,
                           ShareLinkEmailSerializer, ShareLinkPasswordSerializer,
+                          ShareLinkVerifyCodeSerializer,
                           ShareLinkTemplateSerializer, ShareLinkSerializer,
                           ViewerSerializer, ViewSessionSerializer)
 from .tasks import send_view_notification_email_task
@@ -1513,19 +1514,13 @@ class ShareLinkRequestAccessView(APIView):
             EmailVerificationToken.objects.filter(share_link=link, email=email).delete()
             verification = EmailVerificationToken.objects.create(share_link=link, email=email)
             
-            # Construct magic link URL
-            access_url = urljoin(
-                settings.SITE_DOMAIN,
-                f"/view/{link.slug}?accessToken={verification.token}"
-            )
-            
             # Send email
             try:
                 target_name = link.document.name if link.document else link.dataroom.name
                 
                 context = {
                     'target_name': target_name,
-                    'access_url': access_url,
+                    'verification_code': verification.token,
                 }
                 
                 text_content = render_to_string('sharelinks/verification_email.txt', context)
@@ -1547,8 +1542,79 @@ class ShareLinkRequestAccessView(APIView):
                 )
 
             return Response(
-                {"message": "Verification link sent. Please check your email to continue.", "verification_required": True},
+                {"message": "Verification code sent. Please check your email to continue.", "verification_required": True},
                 status=status.HTTP_200_OK
+            )
+
+
+@extend_schema(tags=['sharelinks'])
+class ShareLinkVerifyCodeView(APIView):
+    """
+    Verifies the email code for a share link and authorizes the session.
+    """
+    throttle_classes = [PerSlugScopedRateThrottle]
+    throttle_scope = 'password_verify'
+    permission_classes = [permissions.AllowAny]
+
+    @extend_schema(
+        request=ShareLinkVerifyCodeSerializer,
+        responses={200: dict, 400: dict, 401: dict, 404: dict},
+    )
+    def post(self, request, slug, *args, **kwargs):
+        try:
+            link = _get_active_share_link(slug)
+        except NotFound as e:
+            return Response({"message": e.detail}, status=status.HTTP_404_NOT_FOUND)
+
+        if not link.requires_email or not link.requires_email_verification:
+            return Response(
+                {"message": "This link does not require email verification."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        serializer = ShareLinkVerifyCodeSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        email = serializer.validated_data['email']
+        code = serializer.validated_data['code']
+
+        try:
+            with transaction.atomic():
+                verification = EmailVerificationToken.objects.select_for_update().get(
+                    share_link=link,
+                    email__iexact=email,
+                    token=code
+                )
+                if verification.is_expired():
+                    return Response(
+                        {"message": "Verification code has expired. Please request a new one.", "protectionType": "email"},
+                        status=status.HTTP_401_UNAUTHORIZED
+                    )
+
+                # Set session authorization
+                authorized_links = request.session.get('authorized_share_links', {})
+                if str(link.id) not in authorized_links:
+                    authorized_links[str(link.id)] = {}
+                authorized_links[str(link.id)]['password_verified'] = True
+                authorized_links[str(link.id)]['email_verified'] = True
+                authorized_links[str(link.id)]['viewer_email'] = verification.email
+                request.session['authorized_share_links'] = authorized_links
+
+                _dispatch_automation_event(
+                    link,
+                    'email_identified',
+                    {'viewer_email': verification.email},
+                )
+                # Single use verification code consumption
+                verification.delete()
+
+                return Response({"message": "Email verified successfully."}, status=status.HTTP_200_OK)
+
+        except EmailVerificationToken.DoesNotExist:
+            return Response(
+                {"message": "Invalid verification code.", "protectionType": "email"},
+                status=status.HTTP_401_UNAUTHORIZED
             )
 
 

--- a/backend/tests/sharelinks/test_views.py
+++ b/backend/tests/sharelinks/test_views.py
@@ -1624,6 +1624,64 @@ class TestShareLinkEmailProtection:
         assert 'protectionType' in response_view.json()
         assert response_view.json()['protectionType'] == 'email'
 
+    def test_verify_code_success(self, public_client, share_link_requires_email_verification):
+        """Verifying the correct 6-digit code should authorize the session."""
+        # Create a token manually
+        token = EmailVerificationToken.objects.create(
+            share_link=share_link_requires_email_verification,
+            email='viewer@example.com'
+        )
+        assert EmailVerificationToken.objects.count() == 1
+
+        # Post to verify code endpoint
+        verify_url = f'/api/v1/links/{share_link_requires_email_verification.slug}/verify-code/'
+        response = public_client.post(verify_url, {
+            'email': 'viewer@example.com',
+            'code': token.token
+        })
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['message'] == 'Email verified successfully.'
+
+        # Verify token was deleted (consumed)
+        assert EmailVerificationToken.objects.count() == 0
+
+        # Verify access to view-data is now granted
+        view_data_url = f'/api/v1/links/{share_link_requires_email_verification.slug}/view-data/'
+        response_view = public_client.get(view_data_url)
+        assert response_view.status_code == status.HTTP_200_OK
+
+    def test_verify_code_invalid(self, public_client, share_link_requires_email_verification):
+        """Verifying an invalid code should return 401."""
+        token = EmailVerificationToken.objects.create(
+            share_link=share_link_requires_email_verification,
+            email='viewer@example.com'
+        )
+        
+        verify_url = f'/api/v1/links/{share_link_requires_email_verification.slug}/verify-code/'
+        response = public_client.post(verify_url, {
+            'email': 'viewer@example.com',
+            'code': 'wrongcode'
+        })
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.json()['message'] == 'Invalid verification code.'
+
+    def test_verify_code_expired(self, public_client, share_link_requires_email_verification):
+        """Verifying an expired code should return 401."""
+        expired_time = timezone.now() - timedelta(minutes=30)
+        token = EmailVerificationToken.objects.create(
+            share_link=share_link_requires_email_verification,
+            email='viewer@example.com',
+            expires_at=expired_time
+        )
+        
+        verify_url = f'/api/v1/links/{share_link_requires_email_verification.slug}/verify-code/'
+        response = public_client.post(verify_url, {
+            'email': 'viewer@example.com',
+            'code': token.token
+        })
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert 'expired' in response.json()['message'].lower()
+
     def test_request_access_for_dataroom_no_verification_success(self, public_client, dataroom_link_requires_email):
         """
         Requesting access for a dataroom link that requires email should grant access.

--- a/frontend/src/components/viewer/EmailForm.jsx
+++ b/frontend/src/components/viewer/EmailForm.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { requestShareLinkAccess } from '../../services/api';
+import { requestShareLinkAccess, verifyShareLinkCode } from '../../services/api';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { Label } from '../ui/Label';
@@ -8,7 +8,9 @@ import { AccessOwnerCard } from './AccessOwnerCard';
 
 export function EmailForm({ slug, onSuccess, publicMeta = null }) {
   const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false);
 
   const handleSubmit = async (e) => {
@@ -20,12 +22,41 @@ export function EmailForm({ slug, onSuccess, publicMeta = null }) {
       toast.success(response.data.message);
       
       if (response.data.verification_required) {
-        setHasSubmitted(true); // Show "check your email" message
+        setHasSubmitted(true);
       } else {
-        onSuccess(); // No verification needed, grant access immediately
+        onSuccess();
       }
     } catch (err) {
       // Error is handled by the global interceptor's toast.
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleVerify = async (e) => {
+    e.preventDefault();
+    setIsVerifying(true);
+
+    try {
+      const response = await verifyShareLinkCode(slug, email, code);
+      toast.success(response.data.message || 'Email verified successfully.');
+      onSuccess();
+    } catch (err) {
+      // Error is handled by the global interceptor's toast.
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleResend = async () => {
+    setIsLoading(true);
+    try {
+      const response = await requestShareLinkAccess(slug, email);
+      toast.success(response.data.message);
+      setCode('');
+    } catch (err) {
+      // Error is handled by the global interceptor's toast.
+    } finally {
       setIsLoading(false);
     }
   };
@@ -33,11 +64,57 @@ export function EmailForm({ slug, onSuccess, publicMeta = null }) {
   if (hasSubmitted) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
-        <div className="w-full max-w-sm rounded-lg bg-white p-8 text-center shadow-md dark:bg-gray-800">
-          <h1 className="mb-2 text-2xl font-bold dark:text-white">Check Your Email</h1>
-          <p className="mb-6 text-sm text-gray-600 dark:text-gray-400">
-            A verification link has been sent to <strong>{email}</strong>. Please click the link to continue.
+        <div className="w-full max-w-sm rounded-lg bg-white p-8 shadow-md dark:bg-gray-800">
+          <AccessOwnerCard publicMeta={publicMeta} />
+          {!publicMeta ? (
+            <h1 className="mb-2 text-left text-2xl font-bold dark:text-white">Verify Your Email</h1>
+          ) : null}
+          <p className="mb-6 text-left text-sm text-gray-600 dark:text-gray-400">
+            A 6-digit verification code has been sent to <strong>{email}</strong>. Please enter the code below to continue.
           </p>
+          <form onSubmit={handleVerify} className="space-y-6">
+            <div>
+              <Label htmlFor="code" className="dark:text-gray-300">
+                Verification Code
+              </Label>
+              <Input
+                id="code"
+                name="code"
+                type="text"
+                required
+                maxLength={6}
+                pattern="\d{6}"
+                value={code}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
+                className="mt-1 text-center font-mono text-xl tracking-widest"
+                placeholder="000000"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-3">
+              <Button type="submit" className="w-full" disabled={isVerifying || isLoading}>
+                {isVerifying ? 'Verifying...' : 'Verify'}
+              </Button>
+              <div className="flex justify-between items-center text-sm">
+                <button
+                  type="button"
+                  onClick={() => setHasSubmitted(false)}
+                  className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                  disabled={isVerifying || isLoading}
+                >
+                  Change Email
+                </button>
+                <button
+                  type="button"
+                  onClick={handleResend}
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                  disabled={isVerifying || isLoading}
+                >
+                  {isLoading ? 'Sending...' : 'Resend Code'}
+                </button>
+              </div>
+            </div>
+          </form>
         </div>
       </div>
     );

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -280,6 +280,9 @@ export const verifyShareLinkPassword = (slug, password) =>
 export const requestShareLinkAccess = (slug, email) =>
   api.post(`/links/${slug}/request-access/`, { email });
 
+export const verifyShareLinkCode = (slug, email, code) =>
+  api.post(`/links/${slug}/verify-code/`, { email, code });
+
 export const getPublicQnaThreads = (
   slug,
   {

--- a/frontend/src/tests/components/viewer/EmailForm.test.jsx
+++ b/frontend/src/tests/components/viewer/EmailForm.test.jsx
@@ -61,12 +61,15 @@ describe('EmailForm', () => {
     expect(mockOnSuccess).toHaveBeenCalled();
   });
 
-  it('shows "check your email" message when verification is required', async () => {
+  it('shows verification code input and verifies successfully when code is entered', async () => {
     api.requestShareLinkAccess.mockResolvedValue({
       data: {
-        message: 'Verification link sent.',
+        message: 'Verification code sent.',
         verification_required: true,
       },
+    });
+    api.verifyShareLinkCode.mockResolvedValue({
+      data: { message: 'Email verified successfully.' },
     });
 
     renderComponent();
@@ -78,14 +81,25 @@ describe('EmailForm', () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /check your email/i })).toBeInTheDocument();
+      expect(screen.getByText(/a 6-digit verification code has been sent to/i)).toBeInTheDocument();
     });
 
     expect(api.requestShareLinkAccess).toHaveBeenCalledWith(slug, 'test@example.com');
-    expect(toast.success).toHaveBeenCalledWith('Verification link sent.');
-    expect(mockOnSuccess).not.toHaveBeenCalled();
-    expect(screen.getByText(/a verification link has been sent to/i)).toBeInTheDocument();
-    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+    expect(toast.success).toHaveBeenCalledWith('Verification code sent.');
+    expect(screen.getByText(/a 6-digit verification code has been sent to/i)).toBeInTheDocument();
+
+    const codeInput = screen.getByLabelText(/verification code/i);
+    const verifyButton = screen.getByRole('button', { name: /verify/i });
+
+    fireEvent.change(codeInput, { target: { value: '123456' } });
+    fireEvent.click(verifyButton);
+
+    await waitFor(() => {
+      expect(api.verifyShareLinkCode).toHaveBeenCalledWith(slug, 'test@example.com', '123456');
+    });
+
+    expect(toast.success).toHaveBeenCalledWith('Email verified successfully.');
+    expect(mockOnSuccess).toHaveBeenCalled();
   });
 
   it('handles API errors gracefully', async () => {


### PR DESCRIPTION
Eliminated Automatic Scanner Interference: Instead of sending a clickable link that secure email filters can automatically pre-fetch (which was prematurely consuming single-use access tokens), the system now sends a styled 6-digit numeric verification code (OTP).

Introduced Code Verification Screen: When accessing a restricted share link, recipients now see an interactive screen prompting them to enter the 6-digit code sent to their email.

Streamlined Receiver Experience: Recipients can easily request a code resend or edit their email address directly from the page if they made a mistake, ensuring they never get stuck in a verification loop.