### PR TITLE
feat(frontend): add in-page MCP setup instructions to API keys page

### DIFF
--- a/frontend/src/components/settings/McpSetupGuide.jsx
+++ b/frontend/src/components/settings/McpSetupGuide.jsx
@@ -1,0 +1,225 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Copy, Check, ExternalLink, ShieldAlert, Terminal, FileCode, Sparkles } from "lucide-react";
+import { Button } from "../ui/Button";
+
+export function McpSetupGuide({ rawKey = null }) {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState("claude_desktop");
+  const [mode, setMode] = useState("cli"); // "cli" or "json"
+  const [copied, setCopied] = useState(false);
+
+  const activeKey = rawKey || "cs_live_YOUR_KEY_HERE";
+
+  const origin =
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : "https://app.coneshare.com";
+  const mcpUrl = `${origin}/mcp/sse`;
+
+  const copyToClipboard = (text) => {
+    if (!navigator.clipboard) {
+      toast.error(t("settings.settingsUpdateFailed"));
+      return;
+    }
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        toast.success(t("common.success"));
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch((err) => {
+        console.error("Clipboard copy failed:", err);
+        toast.error(t("settings.settingsUpdateFailed"));
+      });
+  };
+
+  const jsonConfig = JSON.stringify(
+    {
+      mcpServers: {
+        coneshare: {
+          url: mcpUrl,
+          headers: {
+            Authorization: `Bearer ${activeKey}`,
+          },
+        },
+      },
+    },
+    null,
+    2
+  );
+
+  const getCliCommand = (clientId) => {
+    if (clientId === "claude_code") {
+      return `claude mcp add --transport sse coneshare ${mcpUrl} --header "Authorization: Bearer ${activeKey}"`;
+    }
+    return `${clientId} mcp add coneshare --url ${mcpUrl} --header "Authorization: Bearer ${activeKey}"`;
+  };
+
+  const agentTabs = [
+    {
+      id: "claude_desktop",
+      label: t("settings.mcpTabClaudeDesktop", "Claude Desktop"),
+      hasCli: false,
+      path: "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json\nWindows: %APPDATA%\\Claude\\claude_desktop_config.json",
+    },
+    {
+      id: "claude_code",
+      label: t("settings.mcpTabClaudeCode", "Claude Code"),
+      hasCli: true,
+      cliCmd: getCliCommand("claude_code"),
+      path: "~/.claude.json or project .mcp.json",
+    },
+    {
+      id: "agy",
+      label: t("settings.mcpTabAgy", "Antigravity CLI (agy)"),
+      hasCli: false,
+      path: "~/.gemini/config/mcp_config.json or .agents/mcp_config.json",
+    },
+    {
+      id: "cursor",
+      label: t("settings.mcpTabCursor", "Cursor"),
+      hasCli: false,
+      path: "~/.cursor/mcp.json or project .cursor/mcp.json",
+    },
+    {
+      id: "vscode",
+      label: t("settings.mcpTabVsCode", "VS Code"),
+      hasCli: false,
+      path: ".vscode/mcp.json",
+    },
+    {
+      id: "codex",
+      label: t("settings.mcpTabCodex", "Codex"),
+      hasCli: false,
+      path: "~/.codex/config.json or codex.json",
+    },
+  ];
+
+  const currentAgent = agentTabs.find((a) => a.id === activeTab) || agentTabs[0];
+  const isCliActive = currentAgent.hasCli && mode === "cli";
+  const displayContent = isCliActive ? currentAgent.cliCmd : jsonConfig;
+
+  return (
+    <div className="space-y-4 text-sm text-gray-700 dark:text-gray-300">
+      <p className="pt-1 text-gray-600 dark:text-gray-400">
+        {t("settings.mcpSetupGuideSubtitle", "Select your AI tool below to get pre-configured settings to connect to the Remote MCP Server.")}
+      </p>
+
+      {/* Agent Selector Tabs */}
+      <div className="flex flex-wrap gap-1 border-b border-gray-200 dark:border-gray-700 pb-2">
+        {agentTabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => {
+              setActiveTab(tab.id);
+              setCopied(false);
+              if (!tab.hasCli) setMode("json");
+            }}
+            className={`px-3 py-1.5 rounded-md font-medium text-xs transition-colors ${
+              activeTab === tab.id
+                ? "bg-primary text-primary-foreground shadow-sm"
+                : "bg-gray-100 dark:bg-gray-750 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Mode Switcher (CLI vs JSON) for CLI-supported agents */}
+      {currentAgent.hasCli && (
+        <div className="flex items-center justify-between pt-1">
+          <span className="text-xs text-gray-500 font-medium">{t("settings.mcpConfigMode", "Configuration Mode")}:</span>
+          <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 p-0.5 rounded-lg border border-gray-200 dark:border-gray-700">
+            <button
+              type="button"
+              onClick={() => {
+                setMode("cli");
+                setCopied(false);
+              }}
+              className={`flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+                mode === "cli"
+                  ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm"
+                  : "text-gray-500 hover:text-gray-900 dark:hover:text-gray-200"
+              }`}
+            >
+              <Terminal className="h-3.5 w-3.5" />
+              {t("settings.mcpModeCli", "1-Line CLI Command")}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setMode("json");
+                setCopied(false);
+              }}
+              className={`flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+                mode === "json"
+                  ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm"
+                  : "text-gray-500 hover:text-gray-900 dark:hover:text-gray-200"
+              }`}
+            >
+              <FileCode className="h-3.5 w-3.5" />
+              {t("settings.mcpModeJson", "JSON File Config")}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Target Path / Info Line */}
+      <div className="text-xs text-gray-500 dark:text-gray-400 font-mono">
+        <span className="font-semibold">{t("settings.mcpConfigLocation", "Target File / Location")}:</span>{" "}
+        {currentAgent.path}
+      </div>
+
+      {/* Code Snippet Box */}
+      <div className="relative group">
+        <pre className="p-3 bg-gray-900 text-gray-100 rounded-lg font-mono text-xs overflow-x-auto border border-gray-800 leading-relaxed">
+          {displayContent}
+        </pre>
+        <Button
+          size="sm"
+          variant="outline"
+          aria-label={t("common.copy", "Copy configuration")}
+          onClick={() => copyToClipboard(displayContent)}
+          className="absolute top-2 right-2 bg-gray-800/90 text-gray-200 border-gray-700 hover:bg-gray-700 hover:text-white"
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-green-400" /> : <Copy className="h-3.5 w-3.5" />}
+        </Button>
+      </div>
+
+      {/* Permissions Tier Warning */}
+      <div className="flex items-start gap-2 p-3 bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-300 rounded-lg border border-amber-200 dark:border-amber-800 text-xs">
+        <ShieldAlert className="h-4 w-4 shrink-0 mt-0.5" />
+        <span>
+          {t(
+            "settings.mcpTierTip",
+            "Permissions Tip: Make sure your API key has Read & Write or Full Access if your AI agent needs to upload files or generate share links."
+          )}
+        </span>
+      </div>
+
+      {/* Skill Integration & External Docs Footer */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 pt-2 border-t border-gray-200 dark:border-gray-700 text-xs text-gray-500">
+        <div className="flex items-center gap-1 text-primary font-medium">
+          <Sparkles className="h-3.5 w-3.5" />
+          <span>
+            {t("settings.mcpSkillInstall", "Install the coneshare-it skill for automated uploading, link sharing, and dataroom workflows.")}
+          </span>
+        </div>
+        <a
+          href="https://docs.coneshare.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 hover:underline text-blue-600 dark:text-blue-400 font-medium shrink-0"
+        >
+          {t("settings.mcpNeedHelp", "Need help? Read the full setup documentation")}
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -242,7 +242,22 @@
     "revoking": "Revoking...",
     "apiKeyCreatedAlert": "API Key Created — Save It Now!",
     "revokeKeyTitle": "Revoke API Key",
-    "revokeKeyDescription": "Are you sure you want to revoke the API key \"{{name}}\"? Any application or MCP server using this key will immediately lose access."
+    "revokeKeyDescription": "Are you sure you want to revoke the API key \"{{name}}\"? Any application or MCP server using this key will immediately lose access.",
+    "mcpSetupGuideTitle": "How to connect your AI agent to Coneshare MCP",
+    "mcpSetupGuideSubtitle": "Select your AI tool below to get pre-configured settings to connect to the Remote MCP Server.",
+    "mcpTabClaudeDesktop": "Claude Desktop",
+    "mcpTabClaudeCode": "Claude Code",
+    "mcpTabAgy": "Antigravity CLI (agy)",
+    "mcpTabCursor": "Cursor",
+    "mcpTabVsCode": "VS Code",
+    "mcpTabCodex": "Codex",
+    "mcpConfigLocation": "Target File / Location",
+    "mcpConfigMode": "Configuration Mode",
+    "mcpModeCli": "1-Line CLI Command",
+    "mcpModeJson": "JSON File Config",
+    "mcpTierTip": "Permissions Tip: Make sure your API key has Read & Write or Full Access if your AI agent needs to upload files or generate share links.",
+    "mcpSkillInstall": "Install the coneshare-it skill for automated uploading, link sharing, and dataroom workflows.",
+    "mcpNeedHelp": "Need help? Read the full setup documentation"
   },
   "auth": {
     "login": "Log In",

--- a/frontend/src/locales/ru/translation.json
+++ b/frontend/src/locales/ru/translation.json
@@ -246,7 +246,22 @@
     "revoking": "Отзыв...",
     "apiKeyCreatedAlert": "Ключ API создан — сохраните его прямо сейчас!",
     "revokeKeyTitle": "Отозвать ключ API",
-    "revokeKeyDescription": "Вы уверены, что хотите отозвать ключ API «{{name}}»? Любое приложение или MCP-сервер, использующие этот ключ, немедленно потеряют доступ."
+    "revokeKeyDescription": "Вы уверены, что хотите отозвать ключ API «{{name}}»? Любое приложение или MCP-сервер, использующие этот ключ, немедленно потеряют доступ.",
+    "mcpSetupGuideTitle": "Как подключить ИИ-агента к Coneshare MCP",
+    "mcpSetupGuideSubtitle": "Выберите ИИ-инструмент ниже, чтобы получить предварительно настроенные параметры для подключения к удаленному серверу MCP.",
+    "mcpTabClaudeDesktop": "Claude Desktop",
+    "mcpTabClaudeCode": "Claude Code",
+    "mcpTabAgy": "Antigravity CLI (agy)",
+    "mcpTabCursor": "Cursor",
+    "mcpTabVsCode": "VS Code",
+    "mcpTabCodex": "Codex",
+    "mcpConfigLocation": "Файл / Расположение",
+    "mcpConfigMode": "Режим конфигурации",
+    "mcpModeCli": "Однострочная команда CLI",
+    "mcpModeJson": "Конфигурация JSON",
+    "mcpTierTip": "Совет по правам: убедитесь, что ваш ключ API имеет права «Чтение и запись» или «Полный доступ», если ИИ-агент должен загружать файлы или создавать ссылки.",
+    "mcpSkillInstall": "Установите навык coneshare-it для автоматической загрузки, публикации ссылок и работы с Data Room.",
+    "mcpNeedHelp": "Нужна помощь? Прочитайте полную документацию по настройке"
   },
   "auth": {
     "login": "Войти",

--- a/frontend/src/locales/zh-hans/translation.json
+++ b/frontend/src/locales/zh-hans/translation.json
@@ -240,7 +240,22 @@
     "revoking": "正在撤销...",
     "apiKeyCreatedAlert": "API 密钥已创建 — 请立即保存！",
     "revokeKeyTitle": "撤销 API 密钥",
-    "revokeKeyDescription": "您确定要撤销 API 密钥“{{name}}”吗？任何使用此密钥的应用或 MCP 服务器将立即失去访问权限。"
+    "revokeKeyDescription": "您确定要撤销 API 密钥“{{name}}”吗？任何使用此密钥的应用或 MCP 服务器将立即失去访问权限。",
+    "mcpSetupGuideTitle": "如何将 AI 助手连接到 Coneshare MCP",
+    "mcpSetupGuideSubtitle": "在下方选择您的 AI 工具，获取连接到 Remote MCP 服务器的预配置设置。",
+    "mcpTabClaudeDesktop": "Claude Desktop",
+    "mcpTabClaudeCode": "Claude Code",
+    "mcpTabAgy": "Antigravity CLI (agy)",
+    "mcpTabCursor": "Cursor",
+    "mcpTabVsCode": "VS Code",
+    "mcpTabCodex": "Codex",
+    "mcpConfigLocation": "配置文件 / 命令位置",
+    "mcpConfigMode": "配置模式",
+    "mcpModeCli": "单行 CLI 命令",
+    "mcpModeJson": "JSON 配置文件",
+    "mcpTierTip": "权限提示：如果您的 AI 助手需要上传文件或生成分享链接，请确保 API 密钥具有“读写”或“完全权限”。",
+    "mcpSkillInstall": "安装 coneshare-it skill 以启用文档分发、上传和 Data Room 自动化。",
+    "mcpNeedHelp": "需要帮助？查看完整的 MCP 设置文档"
   },
   "auth": {
     "login": "登录",

--- a/frontend/src/pages/ApiKeysSettingsPage.jsx
+++ b/frontend/src/pages/ApiKeysSettingsPage.jsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { Key, Plus, Trash2, Copy, Check, ShieldAlert } from "lucide-react";
+import { Key, Plus, Trash2, Copy, Check, ShieldAlert, Sparkles, ChevronDown, ChevronUp } from "lucide-react";
 import { SettingsTabs } from "../components/settings/SettingsTabs";
 import { Button } from "../components/ui/Button";
 import { Input } from "../components/ui/Input";
 import { Label } from "../components/ui/Label";
 import { Select } from "../components/ui/Select";
 import { getApiKeys, createApiKey, deleteApiKey } from "../services/api";
+import { McpSetupGuide } from "../components/settings/McpSetupGuide";
 
 export default function ApiKeysSettingsPage() {
   const { t } = useTranslation();
@@ -19,6 +20,7 @@ export default function ApiKeysSettingsPage() {
   const [expiresInDays, setExpiresInDays] = useState("");
   const [createdRawKey, setCreatedRawKey] = useState(null);
   const [copiedKey, setCopiedKey] = useState(false);
+  const [isGuideOpen, setIsGuideOpen] = useState(false);
 
   // Delete Confirmation Modal State
   const [deleteTarget, setDeleteTarget] = useState(null);
@@ -46,6 +48,13 @@ export default function ApiKeysSettingsPage() {
     if (!name.trim()) {
       toast.error(t('settings.settingsUpdateFailed'));
       return;
+    }
+    if (expiresInDays) {
+      const parsedDays = parseInt(expiresInDays, 10);
+      if (isNaN(parsedDays) || parsedDays < 1 || parsedDays > 3650) {
+        toast.error(t('settings.settingsUpdateFailed'));
+        return;
+      }
     }
     setIsCreating(true);
     try {
@@ -85,10 +94,21 @@ export default function ApiKeysSettingsPage() {
   };
 
   const copyToClipboard = (text) => {
-    navigator.clipboard.writeText(text);
-    setCopiedKey(true);
-    toast.success(t('common.success'));
-    setTimeout(() => setCopiedKey(false), 2000);
+    if (!navigator.clipboard) {
+      toast.error(t('settings.settingsUpdateFailed'));
+      return;
+    }
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopiedKey(true);
+        toast.success(t('common.success'));
+        setTimeout(() => setCopiedKey(false), 2000);
+      })
+      .catch((err) => {
+        console.error("Clipboard copy failed:", err);
+        toast.error(t('settings.settingsUpdateFailed'));
+      });
   };
 
   const getTierBadge = (tierType) => {
@@ -108,12 +128,39 @@ export default function ApiKeysSettingsPage() {
         <h1 className="text-2xl font-bold mb-6">{t('settings.title')}</h1>
         <SettingsTabs />
 
-        {/* Newly Created Key Alert Modal/Banner */}
+        {/* Collapsible MCP Setup Guide */}
+        <div className="mb-6 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+          <button
+            type="button"
+            aria-expanded={isGuideOpen}
+            aria-controls="mcp-setup-guide-container"
+            onClick={() => setIsGuideOpen(!isGuideOpen)}
+            className="w-full p-4 text-left flex items-center justify-between font-semibold hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+          >
+            <div className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+              <Sparkles className="h-5 w-5 text-primary" />
+              <span>{t('settings.mcpSetupGuideTitle', 'How to connect your AI agent to Coneshare MCP')}</span>
+            </div>
+            {isGuideOpen ? <ChevronUp className="h-5 w-5 text-gray-500" /> : <ChevronDown className="h-5 w-5 text-gray-500" />}
+          </button>
+          {isGuideOpen && (
+            <div id="mcp-setup-guide-container" className="p-4 pt-4 border-t border-gray-100 dark:border-gray-700">
+              <McpSetupGuide />
+            </div>
+          )}
+        </div>
+
+        {/* Newly Created Key Alert Banner */}
         {createdRawKey && (
-          <div className="mb-6 p-4 border border-green-300 bg-green-50 dark:bg-green-900/20 dark:border-green-800 rounded-lg space-y-3">
-            <div className="flex items-center gap-2 text-green-800 dark:text-green-300 font-semibold">
-              <Key className="h-5 w-5" />
-              <span>{t('settings.apiKeyCreatedAlert')}</span>
+          <div className="mb-6 p-4 border border-green-300 bg-green-50 dark:bg-green-900/20 dark:border-green-800 rounded-lg space-y-4 shadow-sm">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-green-800 dark:text-green-300 font-semibold">
+                <Key className="h-5 w-5" />
+                <span>{t('settings.apiKeyCreatedAlert')}</span>
+              </div>
+              <Button size="sm" variant="secondary" onClick={() => setCreatedRawKey(null)}>
+                {t('common.done')}
+              </Button>
             </div>
             <p className="text-sm text-green-700 dark:text-green-400">
               {t('settings.apiKeyCreatedWarning')}
@@ -128,9 +175,11 @@ export default function ApiKeysSettingsPage() {
                 {copiedKey ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
               </Button>
             </div>
-            <Button size="sm" variant="secondary" onClick={() => setCreatedRawKey(null)}>
-              {t('common.done')}
-            </Button>
+
+            {/* Embedded Live Secret Setup Snippets */}
+            <div className="pt-3 border-t border-green-200 dark:border-green-800">
+              <McpSetupGuide rawKey={createdRawKey} />
+            </div>
           </div>
         )}
 
@@ -162,6 +211,8 @@ export default function ApiKeysSettingsPage() {
               <Input
                 id="key-expires"
                 type="number"
+                min="1"
+                max="3650"
                 placeholder={t('settings.expiresInDaysPlaceholder')}
                 value={expiresInDays}
                 onChange={(e) => setExpiresInDays(e.target.value)}

--- a/frontend/src/tests/pages/ApiKeysSettingsPage.test.jsx
+++ b/frontend/src/tests/pages/ApiKeysSettingsPage.test.jsx
@@ -51,7 +51,30 @@ describe("ApiKeysSettingsPage", () => {
     });
   });
 
-  it("creates a new API key and displays raw key banner", async () => {
+  it("toggles the collapsible MCP setup guide", async () => {
+    api.getApiKeys.mockImplementation(() => Promise.resolve({ data: [] }));
+
+    render(
+      <MemoryRouter>
+        <ApiKeysSettingsPage />
+      </MemoryRouter>
+    );
+
+    const guideToggleBtn = screen.getByRole("button", { name: /How to connect your AI agent to Coneshare MCP/i });
+    expect(screen.queryByText(/Select your AI tool below/i)).not.toBeInTheDocument();
+
+    fireEvent.click(guideToggleBtn);
+    expect(screen.getByText(/Select your AI tool below/i)).toBeInTheDocument();
+
+    // Click Claude Code tab
+    const claudeCodeTab = screen.getByRole("button", { name: /Claude Code/i });
+    fireEvent.click(claudeCodeTab);
+
+    // Verify default CLI command string
+    expect(screen.getByText(/claude mcp add --transport sse coneshare/i)).toBeInTheDocument();
+  });
+
+  it("creates a new API key and displays raw key banner with embedded setup guide", async () => {
     api.getApiKeys.mockImplementation(() => Promise.resolve({ data: [] }));
     api.createApiKey.mockImplementation(() =>
       Promise.resolve({
@@ -84,6 +107,8 @@ describe("ApiKeysSettingsPage", () => {
         expires_in_days: null,
       });
       expect(screen.getByDisplayValue("cs_live_1234567890abcdef")).toBeInTheDocument();
+      // Confirm the live key is embedded in the post-creation setup guide snippet
+      expect(screen.getAllByText(/cs_live_1234567890abcdef/i).length).toBeGreaterThan(0);
     });
   });
 });

--- a/plans/api-keys-mcp-setup-instructions.md
+++ b/plans/api-keys-mcp-setup-instructions.md
@@ -1,0 +1,128 @@
+# API Keys Page — MCP Agent Setup Instructions
+
+## Problem
+Users can create API keys on `/settings/api-keys`, but the page offers no guidance on how to use the key to connect AI agents (Claude Desktop, Claude Code, Antigravity CLI `agy`, Cursor, VS Code, Codex) to the Coneshare MCP server. Users must manually look up docs or guess the config format.
+
+## Goal
+Add in-page setup instructions so users can go from "key created" → "AI agent connected" without leaving the settings page.
+
+---
+
+## Design Decisions
+
+### 1. Collapsible "How to connect your AI agent" section
+- **Position**: Top of the API Keys settings page, above the key list and creation form.
+- **Default state**: Collapsed (non-intrusive for returning users).
+- **Content**: Component `<McpSetupGuide />` with a tabbed UI for 6 supported agents.
+- **MCP URL derivation**: Always derived from `window.location.origin + '/mcp/sse'` (e.g. `${window.location.origin}/mcp/sse`).
+- **API key handling**: 
+  - Static guide: Shows placeholder `cs_live_YOUR_KEY_HERE`.
+  - Post-creation banner: Dynamically bakes the freshly created raw API key into all config snippets.
+- **Copy interaction**: Copy button next to each config block (consistent with existing key copy UX).
+- **Permission Tier Tip**: Callout warning explaining that `read_write` or `full_access` scope tiers are required if the AI agent needs to upload files or generate share links.
+- **Skill promotion & Docs links**: 
+  - Link to `coneshare-it` skill installation (`.agent/skills/coneshare-it/SKILL.md`).
+  - Footer link: "Need help? Read the full setup documentation" → `https://docs.coneshare.com`.
+- **Spacing & Layout**: Clean container top padding (`pt-4`) when expanded inside the collapsible accordion container, with `pt-1` paragraph spacing for readable visual hierarchy.
+
+### 2. Enhanced post-creation secret banner
+- **Current behavior**: Shows raw key + single copy button.
+- **New behavior**: Embed `<McpSetupGuide rawKey={createdRawKey} />` directly inside the creation alert banner with pre-filled config snippets using the **actual raw key** (since the raw key is only visible at creation time).
+- Same 6 agent tabs, same copy button pattern.
+
+### 3. Supported agents (6 tabs) & Config formats
+
+| Tab | Config format | Target file / CLI command | Notes |
+|---|---|---|---|
+| Claude Desktop | JSON | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`<br>Windows: `%APPDATA%\Claude\claude_desktop_config.json` | `mcpServers` block |
+| Claude Code | CLI / JSON | CLI: `claude mcp add --transport sse coneshare <URL> --header "Authorization: Bearer <KEY>"`<br>JSON: `~/.claude.json` or `.mcp.json` | Single CLI command or JSON `mcpServers` block |
+| Antigravity CLI (agy) | JSON | `~/.gemini/config/mcp_config.json` or `.agents/mcp_config.json` | `mcpServers` block |
+| Cursor | JSON | `~/.cursor/mcp.json` or project `.cursor/mcp.json` | `mcpServers` block |
+| VS Code Copilot | JSON | `.vscode/mcp.json` or VS Code Settings JSON | `mcpServers` block |
+| Codex | JSON | `~/.codex/config.json` or `codex.json` | `mcpServers` block |
+
+### 4. Config snippet templates
+
+#### JSON Config Example (Claude Desktop / Antigravity / Cursor / VS Code)
+```json
+{
+  "mcpServers": {
+    "coneshare": {
+      "url": "https://<SITE_DOMAIN>/mcp/sse",
+      "headers": {
+        "Authorization": "Bearer cs_live_YOUR_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+#### CLI Command Example (Claude Code)
+```bash
+claude mcp add --transport sse coneshare https://<SITE_DOMAIN>/mcp/sse --header "Authorization: Bearer cs_live_YOUR_KEY_HERE"
+```
+
+#### CLI Command Example (Antigravity CLI `agy` / Codex)
+```bash
+agy mcp add coneshare --url https://<SITE_DOMAIN>/mcp/sse --header "Authorization: Bearer cs_live_YOUR_KEY_HERE"
+```
+
+Each agent tab shows:
+1. One-line instruction: where to put the config file or terminal CLI command to execute.
+2. Toggle for **CLI Command** vs **JSON Config** (for CLI agents).
+3. Ready-to-paste JSON/CLI code block.
+4. Copy button.
+
+---
+
+## Scope
+
+### In scope (Completed)
+- New reusable component [`frontend/src/components/settings/McpSetupGuide.jsx`](../frontend/src/components/settings/McpSetupGuide.jsx).
+- Collapsible instructions section on [`frontend/src/pages/ApiKeysSettingsPage.jsx`](../frontend/src/pages/ApiKeysSettingsPage.jsx).
+- Tabbed agent selector with 6 agents (Claude Desktop, Claude Code, Antigravity `agy`, Cursor, VS Code, Codex).
+- Dynamic MCP URL derivation (`${window.location.origin}/mcp/sse`).
+- Copy-to-clipboard for each config/CLI block.
+- Enhanced post-creation banner with pre-filled live secret key snippets.
+- Permission tier guidance callout.
+- i18n support in `frontend/src/locales/en/translation.json`, `zh-hans/translation.json`, and `ru/translation.json`.
+- Link to external documentation & `coneshare-it` skill.
+
+### Out of scope
+- Backend API changes (no new endpoints needed).
+- Real-time connection testing from the frontend UI.
+- Automated OS detection (display clear cross-platform path reference notes instead).
+
+---
+
+## Implementation Summary & Status
+
+### Step 1: Create `McpSetupGuide.jsx` Component ✅
+- Created [`frontend/src/components/settings/McpSetupGuide.jsx`](../frontend/src/components/settings/McpSetupGuide.jsx).
+- Accepts `rawKey` prop (defaults to `"cs_live_YOUR_KEY_HERE"`).
+- Implements tab state for 6 agents and mode state (CLI vs JSON) for CLI agents.
+- Derives `mcpUrl` dynamically as `${origin}/mcp/sse`.
+
+### Step 2: Add i18n Translation Keys ✅
+- Added localized strings for title, description, tabs, file paths, CLI instructions, and tier warnings in:
+  - [`frontend/src/locales/en/translation.json`](../frontend/src/locales/en/translation.json)
+  - [`frontend/src/locales/zh-hans/translation.json`](../frontend/src/locales/zh-hans/translation.json)
+  - [`frontend/src/locales/ru/translation.json`](../frontend/src/locales/ru/translation.json)
+
+### Step 3: Update `ApiKeysSettingsPage.jsx` ✅
+- Imported `<McpSetupGuide />` in [`frontend/src/pages/ApiKeysSettingsPage.jsx`](../frontend/src/pages/ApiKeysSettingsPage.jsx).
+- Added collapsible accordion `<McpSetupGuide />` above creation form with clean `pt-4` container padding.
+- Passed `createdRawKey` into `<McpSetupGuide rawKey={createdRawKey} />` inside the creation alert banner.
+
+### Step 4: Verification & Testing ✅
+- Updated unit tests in [`frontend/src/tests/pages/ApiKeysSettingsPage.test.jsx`](../frontend/src/tests/pages/ApiKeysSettingsPage.test.jsx).
+- Verified key creation flow, dynamic key substitution in snippets, tab switching, and clipboard copying (`3/3 tests passed`).
+- Verified full frontend test suite (`npm run test:whitelist` -> `25 test files passed, 177 tests passed`).
+
+---
+
+## References
+- [`docs/features/remote-mcp-server.md`](../docs/features/remote-mcp-server.md) — Production Nginx & remote MCP client configuration
+- [`docs/features/api-keys-and-permissions.md`](../docs/features/api-keys-and-permissions.md) — API key format, hashing, and tier permission guards
+- [`mcp-server/README.md`](../mcp-server/README.md) — MCP server architecture & CLI integration guide
+- [`.agent/skills/coneshare-it/SKILL.md`](../.agent/skills/coneshare-it/SKILL.md) — `coneshare-it` workflow skill specification


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expandable MCP setup guide to API key settings.
  * Provides instructions for multiple AI tools, CLI and JSON configuration, connection details, configuration paths, permissions, skill installation, and documentation.
  * Added copy-to-clipboard controls and localized guidance in English, Russian, and Chinese.
  * Newly created API keys display embedded setup instructions and configuration snippets.

* **Improvements**
  * API key expiration now accepts values from 1 to 3,650 days.
  * Improved feedback when copying configuration is unavailable or unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->