### PR TITLE
feat(frontend): persist document list sorting configuration across re…

### DIFF
--- a/.agent/memory.md
+++ b/.agent/memory.md
@@ -286,4 +286,9 @@ COMPOSE_PROJECT_NAME=coneshare docker-compose exec frontend npm test -- --run sr
 - **Context/Implication:** Django backend exceptions (e.g. Google Drive cloud provider token errors) return raw un-translated English detail strings which bypassed frontend i18n when displayed in toasts or dialogs.
 - **Resolution/Action:** Route backend error messages through `frontend/src/utils/errorTranslator.js` (`getLocalizedErrorMessage`) inside the global Axios response interceptor (`api.js`) and dialog error handlers to map raw backend strings to localized `errors.*` translation keys.
 
+### 2026-08-16 Session Entry
+- **Category:** Architecture Choice
+- **Context/Implication:** The documents list reset to default sorting upon page reloads. In contrast, Datarooms rely on manual index/position order for due diligence workflows.
+- **Resolution/Action:** Added optional `storageKey` persistence to `useSortedList` (`frontend/src/hooks/useSortedList.js`) with validation and fallback to defaults. Enabled `coneshare_documents_sort` on `DocumentsPage` (`frontend/src/pages/DocumentsPage.jsx`) while intentionally keeping `DataroomPage` (`frontend/src/pages/DataroomPage.jsx`) unpersisted to preserve canonical position ordering on reloads.
+
 

--- a/frontend/src/hooks/useSortedList.js
+++ b/frontend/src/hooks/useSortedList.js
@@ -3,10 +3,37 @@ import { useState, useMemo } from 'react';
 export function useSortedList(
   items,
   initialConfig = { key: 'name', direction: 'ascending' },
-  options = { groupByType: true }
+  options = { groupByType: true, storageKey: null, allowedKeys: null }
 ) {
-  const [sortConfig, setSortConfig] = useState(initialConfig);
   const groupByType = options?.groupByType ?? true;
+  const storageKey = options?.storageKey ?? null;
+  const allowedKeys = options?.allowedKeys ?? null;
+
+  const [sortConfig, setSortConfig] = useState(() => {
+    if (storageKey && typeof window !== 'undefined') {
+      try {
+        const storage = window.localStorage;
+        if (storage) {
+          const saved = storage.getItem(storageKey);
+          if (saved) {
+            const parsed = JSON.parse(saved);
+            const isKeyValid =
+              typeof parsed?.key === 'string' &&
+              (!Array.isArray(allowedKeys) || allowedKeys.includes(parsed.key));
+            const isDirValid =
+              parsed?.direction === 'ascending' || parsed?.direction === 'descending';
+
+            if (isKeyValid && isDirValid) {
+              return parsed;
+            }
+          }
+        }
+      } catch (err) {
+        console.warn(`Failed to parse sort configuration from localStorage for key "${storageKey}":`, err);
+      }
+    }
+    return initialConfig;
+  });
 
   const sortedItems = useMemo(() => {
     if (!items) return [];
@@ -49,14 +76,27 @@ export function useSortedList(
 
   const handleSort = (key) => {
     setSortConfig((prevConfig) => {
-      if (prevConfig.key === key) {
-        return {
-          ...prevConfig,
-          direction:
-            prevConfig.direction === "ascending" ? "descending" : "ascending",
-        };
+      const nextConfig =
+        prevConfig.key === key
+          ? {
+              ...prevConfig,
+              direction:
+                prevConfig.direction === "ascending" ? "descending" : "ascending",
+            }
+          : { key, direction: "ascending" };
+
+      if (storageKey && typeof window !== 'undefined') {
+        try {
+          const storage = window.localStorage;
+          if (storage) {
+            storage.setItem(storageKey, JSON.stringify(nextConfig));
+          }
+        } catch (err) {
+          console.warn(`Failed to save sort configuration to localStorage for key "${storageKey}":`, err);
+        }
       }
-      return { key, direction: "ascending" };
+
+      return nextConfig;
     });
   };
 

--- a/frontend/src/pages/DocumentsPage.jsx
+++ b/frontend/src/pages/DocumentsPage.jsx
@@ -26,6 +26,8 @@ import { CloudImportDialog } from '../components/dialogs/CloudImportDialog';
 import { FileRequestSheet } from '../components/filerequests/FileRequestSheet';
 import { TooltipProvider } from '../components/ui/Tooltip';
 
+const ALLOWED_SORT_KEYS = ['name', 'owner', 'updated_at', 'file_size', 'view_count'];
+
 function DocumentsPage() {
   const { t } = useTranslation();
   const { folderId } = useParams();
@@ -68,7 +70,15 @@ function DocumentsPage() {
     return combined;
   }, [folders, documents, showStarredOnly]);
 
-  const { sortedItems: allItems, sortConfig, handleSort } = useSortedList(combinedItems);
+  const { sortedItems: allItems, sortConfig, handleSort } = useSortedList(
+    combinedItems,
+    { key: 'name', direction: 'ascending' },
+    {
+      groupByType: true,
+      storageKey: 'coneshare_documents_sort',
+      allowedKeys: ALLOWED_SORT_KEYS,
+    }
+  );
   const { selection, setSelection, setLastSelectedItem, handleItemSelect, handleClearSelection } = useItemSelection(allItems);
 
   const handleShare = (document) => {

--- a/frontend/src/tests/hooks/useSortedList.test.js
+++ b/frontend/src/tests/hooks/useSortedList.test.js
@@ -97,4 +97,201 @@ describe('useSortedList', () => {
       'No Views',
     ]);
   });
+
+  describe('localStorage persistence', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('should initialize sortConfig from localStorage if valid stored value exists', () => {
+      localStorage.setItem(
+        'test_sort_key',
+        JSON.stringify({ key: 'updated_at', direction: 'descending' })
+      );
+
+      const { result } = renderHook(() =>
+        useSortedList(
+          mockItems,
+          { key: 'name', direction: 'ascending' },
+          { groupByType: true, storageKey: 'test_sort_key' }
+        )
+      );
+
+      expect(result.current.sortConfig).toEqual({
+        key: 'updated_at',
+        direction: 'descending',
+      });
+      expect(result.current.sortedItems.map(item => item.name)).toEqual([
+        'Folder A',
+        'Document C',
+        'Document B',
+      ]);
+    });
+
+    it('should fall back to initialConfig when localStorage contains invalid JSON or structure', () => {
+      localStorage.setItem('test_sort_key', 'invalid json string');
+
+      const { result } = renderHook(() =>
+        useSortedList(
+          mockItems,
+          { key: 'name', direction: 'ascending' },
+          { groupByType: true, storageKey: 'test_sort_key' }
+        )
+      );
+
+      expect(result.current.sortConfig).toEqual({
+        key: 'name',
+        direction: 'ascending',
+      });
+    });
+
+    it('should fall back to initialConfig when localStorage direction is invalid', () => {
+      localStorage.setItem(
+        'test_sort_key',
+        JSON.stringify({ key: 'name', direction: 'invalid_dir' })
+      );
+
+      const { result } = renderHook(() =>
+        useSortedList(
+          mockItems,
+          { key: 'name', direction: 'ascending' },
+          { groupByType: true, storageKey: 'test_sort_key' }
+        )
+      );
+
+      expect(result.current.sortConfig).toEqual({
+        key: 'name',
+        direction: 'ascending',
+      });
+    });
+
+    it('should save updated sortConfig to localStorage on handleSort', () => {
+      const { result } = renderHook(() =>
+        useSortedList(
+          mockItems,
+          { key: 'name', direction: 'ascending' },
+          { groupByType: true, storageKey: 'test_sort_key' }
+        )
+      );
+
+      act(() => {
+        result.current.handleSort('file_size');
+      });
+
+      expect(result.current.sortConfig).toEqual({
+        key: 'file_size',
+        direction: 'ascending',
+      });
+      expect(JSON.parse(localStorage.getItem('test_sort_key'))).toEqual({
+        key: 'file_size',
+        direction: 'ascending',
+      });
+
+      act(() => {
+        result.current.handleSort('file_size');
+      });
+
+      expect(result.current.sortConfig).toEqual({
+        key: 'file_size',
+        direction: 'descending',
+      });
+      expect(JSON.parse(localStorage.getItem('test_sort_key'))).toEqual({
+        key: 'file_size',
+        direction: 'descending',
+      });
+    });
+
+    it('should catch SecurityError and fallback to initialConfig when localStorage is blocked', () => {
+      const originalLocalStorage = window.localStorage;
+      const securityError = new Error('Access is denied');
+      securityError.name = 'SecurityError';
+
+      Object.defineProperty(window, 'localStorage', {
+        get() {
+          throw securityError;
+        },
+        configurable: true,
+      });
+
+      try {
+        const { result } = renderHook(() =>
+          useSortedList(
+            mockItems,
+            { key: 'name', direction: 'ascending' },
+            { groupByType: true, storageKey: 'blocked_key' }
+          )
+        );
+
+        expect(result.current.sortConfig).toEqual({
+          key: 'name',
+          direction: 'ascending',
+        });
+
+        act(() => {
+          result.current.handleSort('updated_at');
+        });
+
+        expect(result.current.sortConfig).toEqual({
+          key: 'updated_at',
+          direction: 'ascending',
+        });
+      } finally {
+        Object.defineProperty(window, 'localStorage', {
+          value: originalLocalStorage,
+          configurable: true,
+          writable: true,
+        });
+      }
+    });
+
+    it('should validate parsed.key against allowedKeys whitelist', () => {
+      localStorage.setItem(
+        'test_sort_key',
+        JSON.stringify({ key: 'unknown_key', direction: 'ascending' })
+      );
+
+      const { result } = renderHook(() =>
+        useSortedList(
+          mockItems,
+          { key: 'name', direction: 'ascending' },
+          {
+            groupByType: true,
+            storageKey: 'test_sort_key',
+            allowedKeys: ['name', 'updated_at', 'file_size'],
+          }
+        )
+      );
+
+      // Falls back to initialConfig since 'unknown_key' is not in allowedKeys
+      expect(result.current.sortConfig).toEqual({
+        key: 'name',
+        direction: 'ascending',
+      });
+    });
+
+    it('should accept stored key if present in allowedKeys whitelist', () => {
+      localStorage.setItem(
+        'test_sort_key',
+        JSON.stringify({ key: 'updated_at', direction: 'descending' })
+      );
+
+      const { result } = renderHook(() =>
+        useSortedList(
+          mockItems,
+          { key: 'name', direction: 'ascending' },
+          {
+            groupByType: true,
+            storageKey: 'test_sort_key',
+            allowedKeys: ['name', 'updated_at', 'file_size'],
+          }
+        )
+      );
+
+      expect(result.current.sortConfig).toEqual({
+        key: 'updated_at',
+        direction: 'descending',
+      });
+    });
+  });
 });
+

--- a/frontend/vitest.whitelist.json
+++ b/frontend/vitest.whitelist.json
@@ -24,6 +24,7 @@
     "src/tests/components/EmptyDocuments.test.jsx",
     "src/tests/pages/TrashPage.test.jsx",
     "src/tests/pages/ApiKeysSettingsPage.test.jsx",
-    "src/tests/i18n.test.jsx"
+    "src/tests/i18n.test.jsx",
+    "src/tests/hooks/useSortedList.test.js"
   ]
 }


### PR DESCRIPTION
…loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document list sorting preferences now persist between sessions.
  * Previously selected sorting is restored when returning to the Documents page.
  * Sorting preferences support validated sorting options and default safely when invalid.

* **Bug Fixes**
  * Improved reliability when saving or loading sorting preferences from local storage.

* **Tests**
  * Added coverage for restoring, validating, and updating saved sorting preferences, including unavailable storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->