### PR TITLE
fix(datarooms): preserve custom item order and exclude soft-deleted d…

### DIFF
--- a/.agent/memory.md
+++ b/.agent/memory.md
@@ -286,9 +286,14 @@ COMPOSE_PROJECT_NAME=coneshare docker-compose exec frontend npm test -- --run sr
 - **Context/Implication:** Django backend exceptions (e.g. Google Drive cloud provider token errors) return raw un-translated English detail strings which bypassed frontend i18n when displayed in toasts or dialogs.
 - **Resolution/Action:** Route backend error messages through `frontend/src/utils/errorTranslator.js` (`getLocalizedErrorMessage`) inside the global Axios response interceptor (`api.js`) and dialog error handlers to map raw backend strings to localized `errors.*` translation keys.
 
-### 2026-08-16 Session Entry
+### 2026-08-16 Session Entry (Documents List Sorting Persistence)
 - **Category:** Architecture Choice
 - **Context/Implication:** The documents list reset to default sorting upon page reloads. In contrast, Datarooms rely on manual index/position order for due diligence workflows.
 - **Resolution/Action:** Added optional `storageKey` persistence to `useSortedList` (`frontend/src/hooks/useSortedList.js`) with validation and fallback to defaults. Enabled `coneshare_documents_sort` on `DocumentsPage` (`frontend/src/pages/DocumentsPage.jsx`) while intentionally keeping `DataroomPage` (`frontend/src/pages/DataroomPage.jsx`) unpersisted to preserve canonical position ordering on reloads.
+
+### 2026-08-16 Session Entry (Dataroom Re-ordering & Position Preservation)
+- **Category:** Gotcha
+- **Context/Implication:** Custom item ordering in Dataroom was previously gated behind `show_file_index` and a strict `len(scope_rows) == total_items` check in `DataroomDetailSerializer.get_items` and `DataroomFolderViewSet.retrieve`. When index number badges were disabled (`show_file_index=False`) or when new items lacked order rows, the `position` field was omitted and custom ordering was discarded, reverting the list to `created_at`.
+- **Resolution/Action:** Apply `DataroomItemOrder` unconditionally across root and subfolder serializers regardless of `show_file_index`, attaching sequential fallback `position` values for newly added items so manual item ordering is always preserved.
 
 

--- a/backend/datarooms/serializers.py
+++ b/backend/datarooms/serializers.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db.models import Count
 
 from .models import Dataroom, DataroomDocument, DataroomFolder, DataroomItemOrder
+from .utils import build_ordered_dataroom_items
 
 HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
 
@@ -167,55 +168,34 @@ class DataroomDetailSerializer(serializers.ModelSerializer):
 
         if request and request.query_params.get('content') == 'full':
             folders = obj.folders.all().order_by('created_at', 'id')
-            documents = obj.documents.all().select_related('document', 'document__created_by').annotate(
+            documents = obj.documents.filter(document__deleted_at__isnull=True).select_related('document', 'document__created_by').annotate(
                 dataroom_view_count=Count('dataroomvisit', distinct=True)
             ).order_by('created_at', 'id')
         else:
             folders = obj.folders.filter(parent__isnull=True).order_by('created_at', 'id')
-            documents = obj.documents.filter(folder__isnull=True).select_related('document', 'document__created_by').annotate(
+            documents = obj.documents.filter(folder__isnull=True, document__deleted_at__isnull=True).select_related('document', 'document__created_by').annotate(
                 dataroom_view_count=Count('dataroomvisit', distinct=True)
             ).order_by('created_at', 'id')
         folders_list = list(folders)
         documents_list = list(documents)
 
-        if obj.show_file_index and not use_full_content:
+        folders_data = [
+            DataroomFolderSerializer(folder, context=serializer_context).data
+            for folder in folders_list
+        ]
+        documents_data = [
+            DataroomDocumentSerializer(document, context=serializer_context).data
+            for document in documents_list
+        ]
+
+        scope_rows = None
+        if not use_full_content:
             scope_rows = list(
                 DataroomItemOrder.objects.filter(dataroom=obj, parent_folder__isnull=True)
                 .order_by("position", "created_at", "id")
             )
-            if scope_rows and len(scope_rows) == (len(folders_list) + len(documents_list)):
-                folder_data_map = {
-                    str(folder.id): DataroomFolderSerializer(folder, context=serializer_context).data
-                    for folder in folders_list
-                }
-                document_data_map = {
-                    str(document.id): DataroomDocumentSerializer(document, context=serializer_context).data
-                    for document in documents_list
-                }
-                ordered_items = []
-                for row in scope_rows:
-                    if row.item_type == DataroomItemOrder.ITEM_TYPE_FOLDER and row.folder_id and str(row.folder_id) in folder_data_map:
-                        ordered_items.append({"type": "folder", **folder_data_map[str(row.folder_id)], "position": row.position})
-                    elif row.item_type == DataroomItemOrder.ITEM_TYPE_DOCUMENT and row.dataroom_document_id and str(row.dataroom_document_id) in document_data_map:
-                        ordered_items.append({"type": "document", **document_data_map[str(row.dataroom_document_id)], "position": row.position})
-                return ordered_items
 
-        merged = []
-        for folder in folders_list:
-            merged.append({
-                'type': 'folder',
-                'created_at': folder.created_at,
-                'data': DataroomFolderSerializer(folder, context=serializer_context).data,
-            })
-        for document in documents_list:
-            merged.append({
-                'type': 'document',
-                'created_at': document.created_at,
-                'data': DataroomDocumentSerializer(document, context=serializer_context).data,
-            })
-
-        merged.sort(key=lambda i: (i['type'] != 'folder', i['created_at'], i['data']['id']))
-        return [{'type': i['type'], **i['data']} for i in merged]
+        return build_ordered_dataroom_items(scope_rows, folders_data, documents_data)
 
 
 class AddContentSerializer(serializers.Serializer):

--- a/backend/datarooms/utils.py
+++ b/backend/datarooms/utils.py
@@ -1,4 +1,6 @@
 from django.utils import timezone
+from datarooms.models import DataroomItemOrder
+
 
 def get_dataroom_storage_folder_name(name, dataroom):
     """
@@ -19,3 +21,46 @@ def get_dataroom_storage_folder_name(name, dataroom):
     suffix = ulid_str[-6:] if len(ulid_str) >= 6 else '000000'
     
     return f"{name} ({timestamp}_{suffix})"
+
+
+def build_ordered_dataroom_items(scope_rows, folders_data, documents_data):
+    """
+    Constructs a unified list of dataroom items with assigned `position` values.
+    If scope_rows exist, items are arranged according to DataroomItemOrder,
+    with any un-ordered remaining items appended sequentially at the end.
+    If no scope_rows exist, items default to folders first, then created_at.
+    """
+    folder_map = {str(item["id"]): item for item in folders_data}
+    doc_map = {str(item["id"]): item for item in documents_data}
+
+    if scope_rows:
+        ordered_items = []
+        used_keys = set()
+        for row in scope_rows:
+            if row.item_type == DataroomItemOrder.ITEM_TYPE_FOLDER and row.folder_id and str(row.folder_id) in folder_map:
+                key = ('folder', str(row.folder_id))
+                ordered_items.append({"type": "folder", **folder_map[str(row.folder_id)], "position": row.position})
+                used_keys.add(key)
+            elif row.item_type == DataroomItemOrder.ITEM_TYPE_DOCUMENT and row.dataroom_document_id and str(row.dataroom_document_id) in doc_map:
+                key = ('document', str(row.dataroom_document_id))
+                ordered_items.append({"type": "document", **doc_map[str(row.dataroom_document_id)], "position": row.position})
+                used_keys.add(key)
+
+        remaining_folders = [{'type': 'folder', **item} for item in folders_data if ('folder', str(item['id'])) not in used_keys]
+        remaining_docs = [{'type': 'document', **item} for item in documents_data if ('document', str(item['id'])) not in used_keys]
+        remaining_items = remaining_folders + remaining_docs
+        remaining_items.sort(key=lambda i: (i['type'] != 'folder', i.get('created_at', ''), str(i.get('id', ''))))
+        next_position = max((i.get('position', 0) for i in ordered_items), default=-1) + 1
+        for idx, item in enumerate(remaining_items):
+            ordered_items.append({**item, 'position': next_position + idx})
+        return ordered_items
+
+    merged = (
+        [{'type': 'folder', **item} for item in folders_data] +
+        [{'type': 'document', **item} for item in documents_data]
+    )
+    merged.sort(key=lambda i: (i['type'] != 'folder', i.get('created_at', ''), str(i.get('id', ''))))
+    for idx, item in enumerate(merged):
+        item['position'] = idx
+    return merged
+

--- a/backend/datarooms/views.py
+++ b/backend/datarooms/views.py
@@ -26,7 +26,7 @@ from documents.fileserver import fileserver_client
 from sharelinks.models import ViewSession
 from sharelinks.serializers import ViewSessionSerializer
 from .models import Dataroom, DataroomDocument, DataroomFolder, DataroomItemOrder
-from .utils import get_dataroom_storage_folder_name
+from .utils import get_dataroom_storage_folder_name, build_ordered_dataroom_items
 from .serializers import (
     AddContentSerializer, DataroomDetailSerializer,
     DataroomDocumentSerializer, DataroomDocumentUpdateSerializer,
@@ -769,33 +769,11 @@ class DataroomFolderViewSet(viewsets.ModelViewSet):
         data['sub_folders'] = sub_folder_data
         data['documents'] = document_data
 
-        if instance.dataroom.show_file_index:
-            scope_rows = list(
-                DataroomItemOrder.objects.filter(dataroom=instance.dataroom, parent_folder=instance)
-                .order_by("position", "created_at", "id")
-            )
-            if scope_rows and len(scope_rows) == (len(sub_folder_data) + len(document_data)):
-                folder_map = {item["id"]: item for item in sub_folder_data}
-                doc_map = {item["id"]: item for item in document_data}
-                merged = []
-                for row in scope_rows:
-                    if row.item_type == DataroomItemOrder.ITEM_TYPE_FOLDER and row.folder_id in folder_map:
-                        merged.append({"type": "folder", **folder_map[row.folder_id], "position": row.position})
-                    elif row.item_type == DataroomItemOrder.ITEM_TYPE_DOCUMENT and row.dataroom_document_id in doc_map:
-                        merged.append({"type": "document", **doc_map[row.dataroom_document_id], "position": row.position})
-            else:
-                merged = (
-                    [{'type': 'folder', **item} for item in sub_folder_data] +
-                    [{'type': 'document', **item} for item in document_data]
-                )
-                merged.sort(key=lambda i: (i['type'] != 'folder', i.get('created_at', ''), i.get('id', '')))
-        else:
-            merged = (
-                [{'type': 'folder', **item} for item in sub_folder_data] +
-                [{'type': 'document', **item} for item in document_data]
-            )
-            merged.sort(key=lambda i: (i['type'] != 'folder', i.get('created_at', ''), i.get('id', '')))
-        data['items'] = merged
+        scope_rows = list(
+            DataroomItemOrder.objects.filter(dataroom=instance.dataroom, parent_folder=instance)
+            .order_by("position", "created_at", "id")
+        )
+        data['items'] = build_ordered_dataroom_items(scope_rows, sub_folder_data, document_data)
         return Response(data)
 
     def perform_create(self, serializer):

--- a/backend/tests/core/test_i18n.py
+++ b/backend/tests/core/test_i18n.py
@@ -132,12 +132,12 @@ class TestUserLanguagePreference:
         user = User.objects.create_user(
             username="inactive@example.com",
             email="inactive@example.com",
-            password="password123",
+            password="StrongPassword123!",
             language="zh-hans",
             is_active=False
         )
         client = APIClient()
         url = reverse('signup_request')
-        resp = client.post(url, {'email': 'inactive@example.com', 'password': 'password123', 'name': 'Inactive User'})
+        resp = client.post(url, {'email': 'inactive@example.com', 'password': 'StrongPassword123!', 'name': 'Inactive User'})
         assert resp.status_code == status.HTTP_202_ACCEPTED
         assert captured.get('language') == 'zh-hans'

--- a/backend/tests/datarooms/test_serializers.py
+++ b/backend/tests/datarooms/test_serializers.py
@@ -105,8 +105,40 @@ class TestDataroomSerializer:
         data = serializer.data
         assert data["items"][0]["type"] == "document"
         assert data["items"][0]["id"] == str(ddoc.id)
+        assert data["items"][0]["position"] == 0
         assert data["items"][1]["type"] == "folder"
         assert data["items"][1]["id"] == str(folder.id)
+        assert data["items"][1]["position"] == 1
+
+    def test_dataroom_detail_serializer_preserves_item_order_when_file_index_disabled(self, dataroom, document, serializer_context):
+        folder = DataroomFolder.objects.create(dataroom=dataroom, name="A Folder", parent=None)
+        ddoc = DataroomDocument.objects.create(dataroom=dataroom, document=document, name=document.name)
+        dataroom.show_file_index = False
+        dataroom.save(update_fields=["show_file_index"])
+
+        DataroomItemOrder.objects.create(
+            dataroom=dataroom,
+            parent_folder=None,
+            item_type=DataroomItemOrder.ITEM_TYPE_DOCUMENT,
+            dataroom_document=ddoc,
+            position=0,
+        )
+        DataroomItemOrder.objects.create(
+            dataroom=dataroom,
+            parent_folder=None,
+            item_type=DataroomItemOrder.ITEM_TYPE_FOLDER,
+            folder=folder,
+            position=1,
+        )
+
+        serializer = DataroomDetailSerializer(instance=dataroom, context=serializer_context)
+        data = serializer.data
+        assert data["items"][0]["type"] == "document"
+        assert data["items"][0]["id"] == str(ddoc.id)
+        assert data["items"][0]["position"] == 0
+        assert data["items"][1]["type"] == "folder"
+        assert data["items"][1]["id"] == str(folder.id)
+        assert data["items"][1]["position"] == 1
 
 
 class TestDataroomFolderSerializer:

--- a/backend/tests/datarooms/test_views.py
+++ b/backend/tests/datarooms/test_views.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
 from rest_framework import status
 
 from datarooms.models import Dataroom, DataroomDocument, DataroomFolder, DataroomItemOrder
@@ -402,6 +403,29 @@ class TestDataroomViewSet:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "ordered_items" in response.data["detail"]
 
+    def test_dataroom_root_items_excludes_soft_deleted_documents(self, api_client, dataroom, document, user, organization):
+        doc_active = document
+        doc_trashed = Document.objects.create(name="Trashed Doc", organization=organization, created_by=user, deleted_at=timezone.now())
+        ddoc_active = DataroomDocument.objects.create(dataroom=dataroom, document=doc_active, name=doc_active.name)
+        ddoc_trashed = DataroomDocument.objects.create(dataroom=dataroom, document=doc_trashed, name=doc_trashed.name)
+
+        # 1. Check GET /api/v1/datarooms/{id}/ does not return trashed document in items
+        detail_url = f'/api/v1/datarooms/{dataroom.id}/'
+        detail_res = api_client.get(detail_url)
+        assert detail_res.status_code == status.HTTP_200_OK
+        returned_item_ids = [item['id'] for item in detail_res.data['items']]
+        assert str(ddoc_active.id) in returned_item_ids
+        assert str(ddoc_trashed.id) not in returned_item_ids
+
+        # 2. Check reorder-items succeeds when passing only active items returned from detail
+        reorder_url = f'/api/v1/datarooms/{dataroom.id}/reorder-items/'
+        reorder_res = api_client.post(reorder_url, {
+            "ordered_items": [
+                {"type": "document", "id": str(ddoc_active.id)},
+            ],
+        }, format="json")
+        assert reorder_res.status_code == status.HTTP_200_OK
+
     def test_reorder_items_other_user_dataroom_returns_404(self, api_client, user2, organization, document):
         other_room = Dataroom.objects.create(name="Other", organization=organization, created_by=user2)
         ddoc = DataroomDocument.objects.create(dataroom=other_room, document=document, name=document.name)
@@ -433,6 +457,59 @@ class TestDataroomViewSet:
             dataroom_document=ddoc,
             position=0,
         ).exists()
+
+        # Check that GET detail endpoint returns items with position and respects custom order
+        detail_res = api_client.get(f'/api/v1/datarooms/{dataroom.id}/')
+        assert detail_res.status_code == status.HTTP_200_OK
+        assert detail_res.data["items"][0]["id"] == str(ddoc.id)
+        assert detail_res.data["items"][0]["position"] == 0
+
+    def test_dataroom_folder_retrieve_preserves_item_order_when_file_index_disabled(self, api_client, dataroom, document, user, organization):
+        parent_folder = DataroomFolder.objects.create(dataroom=dataroom, name="Parent", parent=None)
+        sub_folder = DataroomFolder.objects.create(dataroom=dataroom, name="Sub", parent=parent_folder)
+        doc2 = Document.objects.create(name="Doc In Folder", organization=organization, created_by=user)
+        ddoc = DataroomDocument.objects.create(dataroom=dataroom, document=doc2, name=doc2.name, folder=parent_folder)
+        dataroom.show_file_index = False
+        dataroom.save(update_fields=["show_file_index"])
+
+        DataroomItemOrder.objects.create(
+            dataroom=dataroom,
+            parent_folder=parent_folder,
+            item_type=DataroomItemOrder.ITEM_TYPE_DOCUMENT,
+            dataroom_document=ddoc,
+            position=0,
+        )
+        DataroomItemOrder.objects.create(
+            dataroom=dataroom,
+            parent_folder=parent_folder,
+            item_type=DataroomItemOrder.ITEM_TYPE_FOLDER,
+            folder=sub_folder,
+            position=1,
+        )
+
+        folder_url = f'/api/v1/dataroom-folders/{parent_folder.id}/'
+        response = api_client.get(folder_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["items"][0]["type"] == "document"
+        assert response.data["items"][0]["id"] == str(ddoc.id)
+        assert response.data["items"][0]["position"] == 0
+        assert response.data["items"][1]["type"] == "folder"
+        assert response.data["items"][1]["id"] == str(sub_folder.id)
+        assert response.data["items"][1]["position"] == 1
+
+    def test_dataroom_folder_retrieve_excludes_soft_deleted_documents(self, api_client, dataroom, document, user, organization):
+        parent_folder = DataroomFolder.objects.create(dataroom=dataroom, name="Parent Folder", parent=None)
+        doc_active = document
+        doc_trashed = Document.objects.create(name="Trashed Doc in Folder", organization=organization, created_by=user, deleted_at=timezone.now())
+        ddoc_active = DataroomDocument.objects.create(dataroom=dataroom, document=doc_active, name=doc_active.name, folder=parent_folder)
+        ddoc_trashed = DataroomDocument.objects.create(dataroom=dataroom, document=doc_trashed, name=doc_trashed.name, folder=parent_folder)
+
+        folder_url = f'/api/v1/dataroom-folders/{parent_folder.id}/'
+        response = api_client.get(folder_url)
+        assert response.status_code == status.HTTP_200_OK
+        returned_item_ids = [item['id'] for item in response.data['items']]
+        assert str(ddoc_active.id) in returned_item_ids
+        assert str(ddoc_trashed.id) not in returned_item_ids
 
     def test_reorder_items_after_moving_content_should_succeed(self, api_client, dataroom, document, user, organization):
         # 1. Setup a destination folder and a document inside it.


### PR DESCRIPTION
…ocuments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document-list sorting now persists between visits.
* **Bug Fixes**
  * Preserved custom dataroom item ordering, including when file indexing is disabled.
  * Applied consistent positions to folders and documents without saved order entries.
  * Excluded soft-deleted documents from dataroom listings.
  * Maintained reliable item positions across root, full-content, and nested-folder views.
* **Tests**
  * Added coverage for ordering, positions, file-index settings, and deleted-document handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->