### PR TITLE
fix(backend): return 404 for unmatched paths instead of 500 error (#302)

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -17,8 +17,7 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path, re_path
-from django.views.generic import TemplateView
+from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework_simplejwt.views import TokenRefreshView
 
@@ -55,7 +54,3 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-
-# This catch-all route serves the React app for non-API paths only.
-# It must be the last URL pattern in the list so API 404s are not swallowed.
-urlpatterns.append(re_path(r'^(?!api/).*$', TemplateView.as_view(template_name="index.html")))

--- a/backend/docker.dist/runtime/coneshare.nginx.conf
+++ b/backend/docker.dist/runtime/coneshare.nginx.conf
@@ -50,7 +50,12 @@
       try_files $uri $uri/ /index.html;
     }
 
-    location /api {
+    location /api/ {
+      # checks for static file, if not found proxy to app
+      try_files $uri @proxy_to_app;
+    }
+
+    location /api-auth/ {
       # checks for static file, if not found proxy to app
       try_files $uri @proxy_to_app;
     }

--- a/backend/tests/core/test_url_routing.py
+++ b/backend/tests/core/test_url_routing.py
@@ -1,0 +1,45 @@
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/apikeys.txt",
+        "/apis/.env",
+        "/apis/.env.production",
+        "/apis/phpinfo.php",
+        "/apiXYZ",
+        "/api/v1/nonexistent-endpoint/",
+        "/api/schema/nonexistent/",
+        "/nonexistent-path/",
+        "/unknown/sub/path",
+    ],
+)
+def test_unmatched_routes_return_404_not_500(client, path):
+    """
+    Ensure unmatched paths (including paths starting with /api or /apis)
+    return HTTP 404 Not Found rather than raising TemplateDoesNotExist (HTTP 500).
+    Ref: https://github.com/coneshare/coneshare/issues/302
+    """
+    response = client.get(path)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_registered_api_routes_accessible(client):
+    """
+    Ensure registered public API endpoints continue to resolve properly.
+    """
+    response = client.get("/api/v1/languages/")
+    assert response.status_code == status.HTTP_200_OK
+
+    response = client.get("/api/v1/public/settings/")
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unmatched or suspicious URLs now return a proper 404 response instead of a server error.
  * API and authentication routes are handled more reliably.
  * Registered public API endpoints remain accessible as expected.

* **Tests**
  * Added coverage to verify URL routing behavior and API availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->