### PR TITLE
fix(quota): resolve negative user total_document_size on cloud import…

### DIFF
--- a/.agent/memory.md
+++ b/.agent/memory.md
@@ -296,4 +296,7 @@ COMPOSE_PROJECT_NAME=coneshare docker-compose exec frontend npm test -- --run sr
 - **Context/Implication:** Custom item ordering in Dataroom was previously gated behind `show_file_index` and a strict `len(scope_rows) == total_items` check in `DataroomDetailSerializer.get_items` and `DataroomFolderViewSet.retrieve`. When index number badges were disabled (`show_file_index=False`) or when new items lacked order rows, the `position` field was omitted and custom ordering was discarded, reverting the list to `created_at`.
 - **Resolution/Action:** Apply `DataroomItemOrder` unconditionally across root and subfolder serializers regardless of `show_file_index`, attaching sequential fallback `position` values for newly added items so manual item ordering is always preserved.
 
-
+### 2026-08-22 Session Entry
+- **Category:** Gotcha
+- **Context/Implication:** `delete_folder_and_contents` subtracts the aggregate size of all documents inside a folder from `folder.created_by`. While regular user folders and datarooms are strictly single-user in the current architecture, folders with `created_by=None` (such as the organization `__root__` folder) will not deduct quota from document owners if deleted directly.
+- **Resolution/Action:** Be aware that multi-user shared folders or root-level folder deletions in future features will require grouping quota deductions by `created_by` across the deleted documents.

--- a/backend/cloudfiles/serializers.py
+++ b/backend/cloudfiles/serializers.py
@@ -14,7 +14,7 @@ class CloudConnectionSerializer(serializers.ModelSerializer):
 class CloudImportSerializer(serializers.Serializer):
     file_id = serializers.CharField(max_length=1024)
     file_name = serializers.CharField(max_length=255)
-    file_size = serializers.IntegerField()
+    file_size = serializers.IntegerField(min_value=0)
 
 
 class OAuthCallbackSerializer(serializers.Serializer):

--- a/backend/cloudfiles/services.py
+++ b/backend/cloudfiles/services.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.db import transaction
+from django.db.models import F
 
 from core.models import User
 from documents.models import Document, DocumentVersion, Folder
@@ -18,6 +20,9 @@ def create_document_for_import(
     Creates a document record for a file being imported from a cloud service.
     The document is created in an 'uploading' state.
     """
+    if file_size < 0:
+        raise ValueError("file_size must be non-negative.")
+
     # 1. Find or create the destination folder for this provider
     folder_mapping = settings.CLOUD_IMPORT_FOLDER_MAPPING
     folder_name = folder_mapping.get(connection.provider, f"{connection.get_provider_display()} Imports")
@@ -37,31 +42,37 @@ def create_document_for_import(
         original_name=file_name
     )
 
-    # 3. Create database records in 'uploading' state
-    document = Document.objects.create(
-        organization=requesting_user.organization,
-        created_by=requesting_user,
-        name=unique_name,
-        folder=import_folder,
-        status='uploading',
-        status_message='Import scheduled.',
-        file_size=file_size,
-    )
+    # 3. Create database records in 'uploading' state and update user quota atomically
+    with transaction.atomic():
+        document = Document.objects.create(
+            organization=requesting_user.organization,
+            created_by=requesting_user,
+            name=unique_name,
+            folder=import_folder,
+            status='uploading',
+            status_message='Import scheduled.',
+            file_size=file_size,
+        )
 
-    DocumentVersion.objects.create(
-        document=document,
-        version_number=1,
-        file_size=file_size,
-        is_primary=True,
-        metadata={
-            "cloud_import": {
-                "provider": connection.provider,
-                "provider_display": connection.get_provider_display(),
-                "connection_id": str(connection.id),
-                "file_id": file_id_or_path
+        DocumentVersion.objects.create(
+            document=document,
+            version_number=1,
+            file_size=file_size,
+            is_primary=True,
+            metadata={
+                "cloud_import": {
+                    "provider": connection.provider,
+                    "provider_display": connection.get_provider_display(),
+                    "connection_id": str(connection.id),
+                    "file_id": file_id_or_path
+                }
             }
-        }
-    )
+        )
+
+        if file_size:
+            User.objects.filter(pk=requesting_user.pk).update(
+                total_document_size=F('total_document_size') + file_size
+            )
 
     # 4. Trigger the async import task
     import_from_cloud_task.delay(document.id, connection.id, file_id_or_path)

--- a/backend/cloudfiles/views.py
+++ b/backend/cloudfiles/views.py
@@ -383,7 +383,7 @@ class CloudImportVersionView(APIView):
         connection_id = serializers.CharField(max_length=255)
         file_id = serializers.CharField(max_length=1024)
         file_name = serializers.CharField(max_length=255)
-        file_size = serializers.IntegerField()
+        file_size = serializers.IntegerField(min_value=0)
 
     @extend_schema(
         request=ImportVersionSerializer,

--- a/backend/datarooms/services.py
+++ b/backend/datarooms/services.py
@@ -1,0 +1,153 @@
+import logging
+from django.db import transaction
+from django.db.models import Q
+
+from documents.models import Folder, Document
+from documents.services import delete_document_and_files
+from .models import Dataroom, DataroomDocument, DataroomFolder
+from .utils import get_dataroom_storage_folder_name
+
+logger = logging.getLogger(__name__)
+
+
+def delete_dataroom(dataroom: Dataroom):
+    """
+    Explicitly deletes a Dataroom:
+    1. Removes all dataroom items using reference-aware cleanup (preserving documents
+       that are linked in other datarooms).
+    2. Deletes or moves any remaining backing folder under 'Dataroom Uploads'.
+    3. Deletes the Dataroom model record.
+    """
+    organization = dataroom.organization
+    root_folder = Folder.objects.get_root_for_org(organization)
+
+    # 1. Clean up all Dataroom items with reference counting
+    all_doc_ids = list(dataroom.documents.values_list('id', flat=True))
+    all_folder_ids = list(dataroom.folders.values_list('id', flat=True))
+    if all_doc_ids or all_folder_ids:
+        remove_dataroom_content(dataroom, dataroom_doc_ids=all_doc_ids, dataroom_folder_ids=all_folder_ids)
+
+    # 2. Clean up backing storage folder under 'Dataroom Uploads'
+    if root_folder:
+        dataroom_uploads_query = Folder.objects.filter(
+            organization=organization,
+            parent=root_folder,
+            name="Dataroom Uploads"
+        )
+        if dataroom.created_by:
+            dataroom_uploads_query = dataroom_uploads_query.filter(created_by=dataroom.created_by)
+
+        target_folder_name = get_dataroom_storage_folder_name(dataroom.name, dataroom)
+        dataroom_folder = Folder.objects.filter(
+            organization=organization,
+            parent__in=dataroom_uploads_query,
+            name=target_folder_name
+        ).first()
+        if dataroom_folder:
+            dataroom_uploads_folder = dataroom_folder.parent
+            # If there are any documents still in this folder (e.g. preserved shared files),
+            # move them up to the parent 'Dataroom Uploads' folder before deleting this specific folder.
+            descendants = dataroom_folder.get_descendants()
+            folders_to_check = [dataroom_folder] + descendants
+            remaining_docs = Document.objects.filter(folder__in=folders_to_check)
+            if remaining_docs.exists():
+                remaining_docs.update(folder=dataroom_uploads_folder)
+            try:
+                Folder.objects.filter(id__in=[f.id for f in folders_to_check]).delete()
+            except Exception as e:
+                logger.exception("Failed to clean up backing folder %s for dataroom %s: %s", dataroom_folder.id, dataroom.id, e)
+
+    # 3. Delete the Dataroom record
+    dataroom.delete()
+
+
+def remove_dataroom_content(dataroom: Dataroom, dataroom_doc_ids: list = None, dataroom_folder_ids: list = None):
+    """
+    Explicitly removes documents and folders from a Dataroom:
+    1. Identifies all DataroomDocument rows being deleted (including in subfolders).
+    2. For direct uploads that have no other references in other datarooms, deletes
+       the backing Document, storage files, and decrements quota.
+    3. Deletes DataroomDocument and DataroomFolder records.
+    """
+    dataroom_doc_ids = dataroom_doc_ids or []
+    dataroom_folder_ids = dataroom_folder_ids or []
+
+    # 1. Expand all descendant folder IDs
+    all_folder_ids = set(dataroom_folder_ids)
+    if dataroom_folder_ids:
+        folders_to_check = list(DataroomFolder.objects.filter(id__in=dataroom_folder_ids, dataroom=dataroom))
+        stack = list(folders_to_check)
+        while stack:
+            f = stack.pop()
+            for child in f.children.all():
+                all_folder_ids.add(child.id)
+                stack.append(child)
+
+    # 2. Collect all DataroomDocument objects being removed
+    ddocs_to_remove = list(
+        DataroomDocument.objects.filter(
+            Q(id__in=dataroom_doc_ids) | Q(folder_id__in=all_folder_ids),
+            dataroom=dataroom
+        ).select_related('document', 'document__folder')
+    )
+    ddoc_ids_to_remove = {d.id for d in ddocs_to_remove}
+
+    # 3. Identify direct upload documents that have no other references
+    root_folder = Folder.objects.get_root_for_org(dataroom.organization)
+    dataroom_uploads_folders = []
+    if root_folder:
+        uploads_query = Folder.objects.filter(
+            organization=dataroom.organization,
+            parent=root_folder,
+            name="Dataroom Uploads"
+        )
+        if dataroom.created_by:
+            uploads_query = uploads_query.filter(created_by=dataroom.created_by)
+        dataroom_uploads_folders = list(uploads_query)
+
+    backing_docs_to_delete = []
+    seen_doc_ids = set()
+
+    for ddoc in ddocs_to_remove:
+        doc = ddoc.document
+        if not doc or doc.id in seen_doc_ids:
+            continue
+        seen_doc_ids.add(doc.id)
+
+        # Check if direct upload
+        # TODO: Optimize N+1 SQL queries on deep folder hierarchies by pre-collecting all
+        # descendant folder IDs under 'Dataroom Uploads' into an in-memory set upfront,
+        # then checking `doc.folder_id in direct_upload_folder_ids`.
+        is_direct_upload = False
+        if dataroom_uploads_folders:
+            curr = doc.folder
+            while curr:
+                if curr in dataroom_uploads_folders:
+                    is_direct_upload = True
+                    break
+                curr = curr.parent
+
+        if is_direct_upload:
+            # Check if this document is referenced in any other DataroomDocument
+            other_references_exist = (
+                DataroomDocument.objects.filter(document=doc)
+                .exclude(id__in=ddoc_ids_to_remove)
+                .exists()
+            )
+            if not other_references_exist:
+                backing_docs_to_delete.append(doc)
+
+    # 4. Perform deletion
+    with transaction.atomic():
+        if dataroom_doc_ids:
+            DataroomDocument.objects.filter(id__in=dataroom_doc_ids, dataroom=dataroom).delete()
+        if dataroom_folder_ids:
+            DataroomFolder.objects.filter(id__in=dataroom_folder_ids, dataroom=dataroom).delete()
+
+    # Delete backing documents and storage files for direct uploads with no other references (non-blocking)
+    for doc in backing_docs_to_delete:
+        try:
+            delete_document_and_files(doc)
+        except Exception as e:
+            logger.exception("Failed to clean up backing document %s: %s", doc.id, e)
+

--- a/backend/datarooms/signals.py
+++ b/backend/datarooms/signals.py
@@ -1,11 +1,8 @@
 import logging
-import threading
 
-from django.db.models.signals import post_save, pre_delete
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from documents.models import Folder
-from documents.services import delete_document_and_files
 from sharelinks.models import ShareLinkDataroomSetting
 from .models import DataroomDocument, DataroomFolder
 
@@ -51,65 +48,3 @@ def create_settings_for_new_dataroom_folder(sender, instance, created, **kwargs)
                     'enable_watermark': link.enable_watermark,
                 }
             )
-
-
-# Thread-local storage to track documents currently being deleted in each thread.
-# This prevents cross-thread state leakage and race conditions in multi-threaded environments.
-_thread_local = threading.local()
-
-
-def _get_deleting_docs():
-    if not hasattr(_thread_local, 'deleting_docs'):
-        _thread_local.deleting_docs = set()
-    return _thread_local.deleting_docs
-
-
-@receiver(pre_delete, sender=DataroomDocument)
-def delete_direct_uploaded_document_on_remove(sender, instance, **kwargs):
-    """
-    When a document is removed/deleted from a dataroom, if it was a direct upload
-    (i.e. stored in 'Dataroom Uploads' hierarchy) and there are no other references
-    to it in any dataroom, delete the backing Document model and files from storage.
-    """
-    doc = instance.document
-    deleting_docs = _get_deleting_docs()
-    if not doc or doc.id in deleting_docs:
-        return
-
-    # Check if this document is referenced by any other DataroomDocument.
-    # We exclude the current instance being deleted.
-    other_references_exist = DataroomDocument.objects.filter(document=doc).exclude(pk=instance.pk).exists()
-    if other_references_exist:
-        return
-
-    try:
-        root_folder = Folder.objects.get_root_for_org(doc.organization)
-        dataroom_uploads = Folder.objects.get(
-            organization=doc.organization,
-            parent=root_folder,
-            name="Dataroom Uploads",
-            created_by=doc.created_by
-        )
-    except (Folder.DoesNotExist, Folder.MultipleObjectsReturned):
-        return
-
-    # Check if the document's folder is a descendant of 'Dataroom Uploads'
-    folder = doc.folder
-    is_direct_upload = False
-    while folder:
-        if folder == dataroom_uploads:
-            is_direct_upload = True
-            break
-        folder = folder.parent
-
-    if is_direct_upload:
-        deleting_docs = _get_deleting_docs()
-        deleting_docs.add(doc.id)
-        try:
-            delete_document_and_files(doc)
-        except Exception as e:
-            # Log the error but don't block the DataroomDocument deletion
-            # to prevent transaction blockages.
-            logger.exception("Failed to clean up backing document %s: %s", doc.id, e)
-        finally:
-            deleting_docs.discard(doc.id)

--- a/backend/datarooms/views.py
+++ b/backend/datarooms/views.py
@@ -27,6 +27,7 @@ from documents.fileserver import fileserver_client
 from sharelinks.models import ViewSession
 from sharelinks.serializers import ViewSessionSerializer
 from .models import Dataroom, DataroomDocument, DataroomFolder, DataroomItemOrder
+from .services import delete_dataroom, remove_dataroom_content
 from .utils import get_dataroom_storage_folder_name, build_ordered_dataroom_items
 from .serializers import (
     AddContentSerializer, DataroomDetailSerializer,
@@ -67,29 +68,7 @@ class DataroomViewSet(viewsets.ModelViewSet):
         )
 
     def perform_destroy(self, instance):
-        # 1. Find the corresponding library folder: "Dataroom Uploads / <Dataroom-Name> (<Dataroom-ID>)"
-        root_folder = Folder.objects.get_root_for_org(instance.organization)
-        if root_folder:
-            dataroom_uploads_folder = Folder.objects.filter(
-                organization=instance.organization,
-                parent=root_folder,
-                name="Dataroom Uploads",
-                created_by=instance.created_by
-            ).first()
-            if dataroom_uploads_folder:
-                # Find the specific folder for this dataroom name
-                dataroom_folder = Folder.objects.filter(
-                    organization=instance.organization,
-                    parent=dataroom_uploads_folder,
-                    name=get_dataroom_storage_folder_name(instance.name, instance),
-                    created_by=instance.created_by
-                ).first()
-                if dataroom_folder:
-                    # Delete the folder and its contents using documents.services.delete_folder_and_contents
-                    delete_folder_and_contents(dataroom_folder)
-
-        # 2. Perform the actual dataroom deletion
-        super().perform_destroy(instance)
+        delete_dataroom(instance)
 
     def perform_update(self, serializer):
         old_name = self.get_object().name
@@ -114,7 +93,6 @@ class DataroomViewSet(viewsets.ModelViewSet):
                     if dataroom_folder:
                         dataroom_folder.name = get_dataroom_storage_folder_name(instance.name, instance)
                         dataroom_folder.save()
-
 
     def _scope_has_item_order_rows(self, dataroom, parent_folder):
         return DataroomItemOrder.objects.filter(dataroom=dataroom, parent_folder=parent_folder).exists()
@@ -254,11 +232,7 @@ class DataroomViewSet(viewsets.ModelViewSet):
         dataroom_doc_ids = data.get('dataroom_document_ids', [])
         dataroom_folder_ids = data.get('dataroom_folder_ids', [])
 
-        with transaction.atomic():
-            DataroomDocument.objects.filter(id__in=dataroom_doc_ids, dataroom=dataroom).delete()
-            # Deleting a folder will cascade and delete its children and document references.
-            DataroomFolder.objects.filter(id__in=dataroom_folder_ids, dataroom=dataroom).delete()
-
+        remove_dataroom_content(dataroom, dataroom_doc_ids, dataroom_folder_ids)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _get_unique_dataroom_folder_name(self, dataroom, parent_folder, original_name):
@@ -851,3 +825,6 @@ class DataroomFolderViewSet(viewsets.ModelViewSet):
                 if curr_folder:
                     curr_folder.name = new_name
                     curr_folder.save()
+
+    def perform_destroy(self, instance):
+        remove_dataroom_content(instance.dataroom, dataroom_doc_ids=[], dataroom_folder_ids=[instance.id])

--- a/backend/documents/services.py
+++ b/backend/documents/services.py
@@ -684,7 +684,28 @@ def process_imported_file(document: Document, file_data: dict, version_id=None):
         logger.error(f"Failed to upload imported file to file server for doc {document.id}: {e}")
         raise
 
-    # 2. Update document and version records
+    # 2. Re-check quota with actual size before persisting version storage metadata.
+    user = document.created_by
+    if user:
+        try:
+            check_user_quota_on_upload(
+                user=user,
+                new_file_size=file_size,
+                document_to_update=document if document.file_size else None
+            )
+        except QuotaExceededError as e:
+            logger.warning(
+                f"Cloud import for doc {document.id} failed: quota exceeded with actual file size. "
+                f"User: {user.id}, Size: {file_size}."
+            )
+            # Clean up the file that was just uploaded to our storage
+            try:
+                fileserver_client.delete_file(original_storage_key)
+            except APIException as delete_e:
+                logger.error(f"Failed to clean up file {original_storage_key} after quota error: {delete_e}")
+            raise
+
+    # 3. Update document and version records and route for processing
     if version_id:
         version = document.versions.get(id=version_id)
     else:
@@ -701,40 +722,18 @@ def process_imported_file(document: Document, file_data: dict, version_id=None):
         version.metadata = {}
     if 'cloud_import' in version.metadata:
         version.metadata['cloud_import']['etag_or_rev'] = etag_or_rev
-    
-    version.save()
 
-    # 3. Re-check quota with actual size and route for processing.
-    user = document.created_by
-    if user:
-        try:
-            check_user_quota_on_upload(
-                user=user,
-                new_file_size=file_size,
-                document_to_update=document if (version.version_number > 1) else None
-            )
-        except QuotaExceededError as e:
-            logger.warning(
-                f"Cloud import for doc {document.id} failed: quota exceeded with actual file size. "
-                f"User: {user.id}, Size: {file_size}."
-            )
-            # Clean up the file that was just uploaded to our storage
-            try:
-                fileserver_client.delete_file(original_storage_key)
-            except APIException as delete_e:
-                logger.error(f"Failed to clean up file {original_storage_key} after quota error: {delete_e}")
-            raise
-
-    old_file_size = document.file_size or 0 if version.version_number > 1 else 0
+    old_file_size = document.file_size or 0
 
     with transaction.atomic():
+        version.save()
         _route_document_for_processing(
             document=document,
             version=version,
             file_size=file_size,
             content_type=content_type,
         )
-        if user:
+        if user and old_file_size != file_size:
             User.objects.filter(pk=user.pk).update(
                 total_document_size=F('total_document_size') - old_file_size + file_size
             )

--- a/backend/tests/cloudfiles/test_views.py
+++ b/backend/tests/cloudfiles/test_views.py
@@ -3,8 +3,10 @@ from unittest.mock import patch, MagicMock
 from rest_framework import status
 
 from cloudfiles.models import CloudConnection
+from cloudfiles.services import create_document_for_import
 from core.models import AppConfiguration
 from documents.models import Document, Folder, DocumentVersion
+from documents.services import delete_document_and_files, process_imported_file
 
 
 @pytest.fixture
@@ -634,6 +636,210 @@ def test_refresh_soft_deleted_document_returns_404(api_client, user):
     assert res.status_code == status.HTTP_404_NOT_FOUND
 
 
+@pytest.mark.django_db
+@patch('documents.services.fileserver_client.delete_file')
+@patch('cloudfiles.services.import_from_cloud_task.delay')
+def test_cloud_import_premature_deletion_quota_accounting(mock_task, mock_fs_delete, api_client, user):
+    """
+    RED Test: Initiating a cloud import and deleting the document before download
+    must not result in a negative total_document_size for the user.
+    """
+    connection = CloudConnection.objects.create(
+        user=user,
+        provider='google_drive',
+        email='import_user@gmail.com',
+        access_token='token_123',
+    )
+    user.total_document_size = 0
+    user.save()
 
+    api_client.force_authenticate(user=user)
+    import_url = f'/api/v1/cloud/connections/{connection.id}/import/'
+    file_size = 102656
+
+    # 1. Initiate cloud import
+    res = api_client.post(import_url, {
+        'file_id': 'cloud_file_123',
+        'file_name': 'sample.pdf',
+        'file_size': file_size
+    })
+    assert res.status_code == status.HTTP_202_ACCEPTED
+    doc_id = res.data['id']
+
+    # User's quota must reflect the imported document
+    user.refresh_from_db()
+    assert user.total_document_size == file_size
+
+    # 2. Prematurely delete the document (before download finishes)
+    doc = Document.objects.get(id=doc_id)
+    delete_document_and_files(doc)
+
+    user.refresh_from_db()
+    assert user.total_document_size == 0
+
+
+@pytest.mark.django_db
+@patch('documents.services.fileserver_client.delete_file')
+@patch('cloudfiles.services.import_from_cloud_task.delay')
+def test_cloud_import_process_imported_file_near_quota_limit(mock_task, mock_fs_delete, api_client, user):
+    """
+    Test that process_imported_file does not double-count declared document size
+    when verifying user quota upon download completion.
+    """
+    # Set user quota to 10MB, with 9MB already used
+    user.custom_file_size_quota_mb = 10
+    used_bytes = 9 * 1024 * 1024
+    user.total_document_size = used_bytes
+    user.save()
+
+    # Import a 600KB file (0.6MB). 9MB + 0.6MB = 9.6MB <= 10MB (Valid!)
+    import_size = 600 * 1024
+    connection = CloudConnection.objects.create(
+        user=user,
+        provider='google_drive',
+        email='import_limit@gmail.com',
+        access_token='token_123',
+    )
+
+    doc = create_document_for_import(
+        requesting_user=user,
+        file_name='near_limit.pdf',
+        file_size=import_size,
+        connection=connection,
+        file_id_or_path='cloud_file_near_limit',
+    )
+
+    # Quota is now 9.6MB
+    user.refresh_from_db()
+    assert user.total_document_size == used_bytes + import_size
+
+    import io
+    # Simulate download completing with the exact actual size
+    file_data = {
+        'name': 'near_limit.pdf',
+        'content': io.BytesIO(b'dummy content'),
+        'size': import_size,
+        'etag_or_rev': 'rev_123',
+    }
+
+    with patch('requests.put') as mock_put, patch('documents.services.fileserver_client.generate_upload_url', return_value='http://test/upload'):
+        mock_put.return_value.raise_for_status = MagicMock()
+        # This should succeed without raising QuotaExceededError
+        process_imported_file(doc, file_data)
+
+    user.refresh_from_db()
+    assert user.total_document_size == used_bytes + import_size
+
+
+@pytest.mark.django_db
+def test_cloud_import_negative_file_size_rejected(api_client, user):
+    """
+    Test that negative file_size in cloud import is rejected with 400.
+    """
+    connection = CloudConnection.objects.create(
+        user=user,
+        provider='google_drive',
+        email='neg_user@gmail.com',
+        access_token='token_neg',
+    )
+    api_client.force_authenticate(user=user)
+    import_url = f'/api/v1/cloud/connections/{connection.id}/import/'
+
+    res = api_client.post(import_url, {
+        'file_id': 'cloud_file_neg',
+        'file_name': 'sample.pdf',
+        'file_size': -500
+    })
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'file_size' in res.data
+
+
+@pytest.mark.django_db
+def test_cloud_import_version_negative_file_size_rejected(api_client, user):
+    """
+    Test that negative file_size in cloud import version is rejected with 400.
+    """
+    connection = CloudConnection.objects.create(
+        user=user,
+        provider='google_drive',
+        email='neg_ver_user@gmail.com',
+        access_token='token_neg_ver',
+    )
+    doc = Document.objects.create(
+        organization=user.organization,
+        created_by=user,
+        name='existing.pdf',
+        status='ready',
+        file_size=1000,
+    )
+    DocumentVersion.objects.create(
+        document=doc,
+        version_number=1,
+        file_size=1000,
+        is_primary=True,
+    )
+    api_client.force_authenticate(user=user)
+    import_version_url = f'/api/v1/cloud/documents/{doc.id}/import_version/'
+
+    res = api_client.post(import_version_url, {
+        'connection_id': str(connection.id),
+        'file_id': 'cloud_file_neg_ver',
+        'file_name': 'existing.pdf',
+        'file_size': -500
+    })
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'file_size' in res.data
+
+
+@pytest.mark.django_db
+@patch('documents.services.fileserver_client.delete_file')
+@patch('cloudfiles.services.import_from_cloud_task.delay')
+def test_cloud_import_quota_exceeded_on_process_does_not_dangle_storage_key(mock_task, mock_fs_delete, api_client, user):
+    """
+    Test that when actual file size exceeds user quota during process_imported_file,
+    the version row does not retain a storage_key pointing to the deleted storage object.
+    """
+    import io
+    from documents.services import QuotaExceededError
+
+    user.custom_file_size_quota_mb = 10
+    user.total_document_size = 9 * 1024 * 1024
+    user.save()
+
+    connection = CloudConnection.objects.create(
+        user=user,
+        provider='google_drive',
+        email='quota_fail@gmail.com',
+        access_token='token_123',
+    )
+
+    doc = create_document_for_import(
+        requesting_user=user,
+        file_name='quota_fail.pdf',
+        file_size=500 * 1024,
+        connection=connection,
+        file_id_or_path='cloud_file_quota_fail',
+    )
+
+    # Actual download size is 2MB (9MB + 2MB = 11MB > 10MB limit)
+    actual_size = 2 * 1024 * 1024
+    file_data = {
+        'name': 'quota_fail.pdf',
+        'content': io.BytesIO(b'large content'),
+        'size': actual_size,
+        'etag_or_rev': 'rev_fail',
+    }
+
+    with patch('requests.put') as mock_put, patch('documents.services.fileserver_client.generate_upload_url', return_value='http://test/upload'):
+        mock_put.return_value.raise_for_status = MagicMock()
+        with pytest.raises(QuotaExceededError):
+            process_imported_file(doc, file_data)
+
+    mock_fs_delete.assert_called_once()
+
+    # The version should not have original_storage_key or storage_key persisted
+    v1 = doc.versions.get(version_number=1)
+    assert not v1.storage_key
+    assert not v1.original_storage_key
 
 

--- a/backend/tests/datarooms/test_views.py
+++ b/backend/tests/datarooms/test_views.py
@@ -5,6 +5,7 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.exceptions import APIException
 
 from datarooms.models import Dataroom, DataroomDocument, DataroomFolder, DataroomItemOrder
 from datarooms.utils import get_dataroom_storage_folder_name
@@ -155,6 +156,108 @@ class TestDataroomViewSet:
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not Dataroom.objects.filter(id=dataroom_id).exists()
+
+    @patch('documents.services.fileserver_client.delete_file')
+    def test_delete_dataroom_with_direct_upload_quota_balance(self, mock_fs_delete, api_client, dataroom, user):
+        """
+        Reproduction Test:
+        1. New user with 0 documents, total_document_size = 0.
+        2. Create dataroom and upload a file (~331KB).
+        3. Delete the dataroom.
+        4. User's total_document_size must be 0, not -331697.
+        """
+        user.total_document_size = 0
+        user.save()
+
+        file_size = 331697
+        url_finalize = f'/api/v1/datarooms/{dataroom.id}/uploads/finalize/'
+        data_finalize = {
+            'storage_key': 'org_1/uploads/test_file.pdf',
+            'unique_name': 'test_file.pdf',
+            'file_size': file_size,
+            'content_type': 'application/pdf',
+        }
+        res = api_client.post(url_finalize, data_finalize, format='json')
+        assert res.status_code == status.HTTP_202_ACCEPTED
+
+        user.refresh_from_db()
+        assert user.total_document_size == file_size
+
+        # Delete dataroom
+        res_delete = api_client.delete(f'/api/v1/datarooms/{dataroom.id}/')
+        assert res_delete.status_code == status.HTTP_204_NO_CONTENT
+
+        user.refresh_from_db()
+        assert user.total_document_size == 0, f"Expected total_document_size to be 0, got {user.total_document_size}"
+
+    @patch('documents.services.fileserver_client.delete_file')
+    def test_delete_dataroom_with_shared_direct_upload_preserves_shared_document(self, mock_fs_delete, api_client, dataroom, user, organization):
+        """
+        Test that deleting a dataroom preserves backing documents that are also linked
+        in another dataroom.
+        """
+        second_dataroom = Dataroom.objects.create(
+            name="Second Dataroom",
+            organization=organization,
+            created_by=user
+        )
+
+        url_finalize = f'/api/v1/datarooms/{dataroom.id}/uploads/finalize/'
+        data_finalize = {
+            'storage_key': 'org_1/uploads/shared_file.pdf',
+            'unique_name': 'shared_file.pdf',
+            'file_size': 1024,
+            'content_type': 'application/pdf',
+        }
+        res = api_client.post(url_finalize, data_finalize, format='json')
+        assert res.status_code == status.HTTP_202_ACCEPTED
+
+        doc = Document.objects.get(name='shared_file.pdf')
+
+        # Link the document to the second dataroom as well
+        DataroomDocument.objects.create(
+            dataroom=second_dataroom,
+            document=doc,
+            name='shared_file.pdf'
+        )
+
+        # Delete the first dataroom
+        res_delete = api_client.delete(f'/api/v1/datarooms/{dataroom.id}/')
+        assert res_delete.status_code == status.HTTP_204_NO_CONTENT
+
+        # The document and storage files must be preserved for second_dataroom
+        assert Document.objects.filter(id=doc.id).exists()
+        assert DataroomDocument.objects.filter(dataroom=second_dataroom, document=doc).exists()
+        mock_fs_delete.assert_not_called()
+
+    @patch('documents.services.fileserver_client.delete_file')
+    def test_delete_dataroom_when_created_by_is_none(self, mock_fs_delete, api_client, dataroom, user):
+        """
+        Test that delete_dataroom cleans up storage and backing folders even if
+        dataroom.created_by is None (e.g. user was deleted).
+        """
+        from datarooms.services import delete_dataroom
+
+        url_finalize = f'/api/v1/datarooms/{dataroom.id}/uploads/finalize/'
+        data_finalize = {
+            'storage_key': 'org_1/uploads/orphan_file.pdf',
+            'unique_name': 'orphan_file.pdf',
+            'file_size': 2048,
+            'content_type': 'application/pdf',
+        }
+        res = api_client.post(url_finalize, data_finalize, format='json')
+        assert res.status_code == status.HTTP_202_ACCEPTED
+        doc = Document.objects.get(name='orphan_file.pdf')
+
+        # Simulate user deletion where created_by is SET_NULL
+        dataroom.created_by = None
+        dataroom.save()
+
+        delete_dataroom(dataroom)
+
+        assert not Document.objects.filter(id=doc.id).exists()
+        assert not Dataroom.objects.filter(id=dataroom.id).exists()
+        mock_fs_delete.assert_called_with('org_1/uploads/orphan_file.pdf')
 
     def test_add_content_to_dataroom(self, api_client, dataroom, document):
         """Test adding documents to a dataroom."""
@@ -990,6 +1093,35 @@ class TestDataroomViewSet:
         assert res_again.status_code == status.HTTP_202_ACCEPTED
         assert Document.objects.filter(name='test_file.pdf').exists()
 
+    @patch('documents.services.fileserver_client.delete_file', side_effect=APIException("Storage service unavailable"))
+    def test_remove_content_resilient_to_storage_delete_failure(self, mock_delete_file, api_client, dataroom):
+        """
+        Test that removing content from a dataroom succeeds with 204 even if the fileserver
+        storage deletion encounters an exception.
+        """
+        url_finalize = f'/api/v1/datarooms/{dataroom.id}/uploads/finalize/'
+        data_finalize = {
+            'storage_key': 'org_1/uploads/resilient_test.pdf',
+            'unique_name': 'resilient_test.pdf',
+            'file_size': 1024,
+            'content_type': 'application/pdf',
+        }
+        res = api_client.post(url_finalize, data_finalize, format='json')
+        assert res.status_code == status.HTTP_202_ACCEPTED
+
+        dataroom_doc = DataroomDocument.objects.get(name='resilient_test.pdf', dataroom=dataroom)
+
+        # Remove the document
+        url_remove = f'/api/v1/datarooms/{dataroom.id}/remove-content/'
+        data_remove = {
+            'dataroom_document_ids': [str(dataroom_doc.id)],
+            'dataroom_folder_ids': []
+        }
+        response_remove = api_client.post(url_remove, data_remove, format='json')
+        # Must return 204 without raising 500
+        assert response_remove.status_code == status.HTTP_204_NO_CONTENT
+        assert not DataroomDocument.objects.filter(id=dataroom_doc.id).exists()
+
     @patch('documents.services.fileserver_client.delete_file')
     def test_direct_upload_deletion_with_multiple_dataroom_uploads_folders(self, mock_delete_file, api_client, dataroom, user2):
         """
@@ -1320,4 +1452,43 @@ class TestDataroomDocumentViewSet:
         assert Folder.objects.filter(
             organization=org, parent=dataroom_uploads, name=get_dataroom_storage_folder_name(second_dataroom.name, second_dataroom)
         ).exists()
+
+    def test_delete_dataroom_without_created_by_cleans_up_backing_folder(self, api_client, organization, user):
+        """
+        Test that delete_dataroom cleans up the backing folder even if dataroom.created_by is None.
+        """
+        from documents.models import Folder
+        from datarooms.models import Dataroom
+        from datarooms.services import delete_dataroom
+        from datarooms.utils import get_dataroom_storage_folder_name
+
+        root_folder = Folder.objects.get_root_for_org(organization)
+        user_uploads = Folder.objects.create(
+            organization=organization,
+            parent=root_folder,
+            name="Dataroom Uploads",
+            created_by=user,
+        )
+
+        dr = Dataroom.objects.create(
+            organization=organization,
+            name="No Creator Dataroom",
+            created_by=None,
+        )
+
+        storage_folder_name = get_dataroom_storage_folder_name(dr.name, dr)
+        dr_folder = Folder.objects.create(
+            organization=organization,
+            parent=user_uploads,
+            name=storage_folder_name,
+            created_by=user,
+        )
+
+        assert Folder.objects.filter(id=dr_folder.id).exists()
+
+        delete_dataroom(dr)
+
+        assert not Dataroom.objects.filter(id=dr.id).exists()
+        assert not Folder.objects.filter(id=dr_folder.id).exists()
+
 


### PR DESCRIPTION
… and dataroom deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cloud import quota tracking to prevent double-counting and restore storage accurately when imports are removed.
  - Dataroom deletion now reliably removes associated content while preserving documents shared with other datarooms.
  - Dataroom cleanup continues successfully even when backing-file deletion encounters an error.
  - Corrected storage quota restoration for documents uploaded directly to datarooms, including items without an assigned creator.
- **Tests**
  - Added coverage for cloud import quota accounting and dataroom deletion and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->