### PR TITLE
fix(backend): respect owner language in automation email notifications

### DIFF
--- a/backend/automations/emails.py
+++ b/backend/automations/emails.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo
 
 from django.utils.dateparse import parse_datetime
 from django.utils import timezone
+from django.utils.translation import gettext as _, override as translation_override
 from django.core.mail import send_mail
 from django.conf import settings
 from django.db import transaction
@@ -19,21 +20,49 @@ from . import tasks
 
 logger = logging.getLogger(__name__)
 
-def _build_notification_headline(viewer: str, target_type: str, target_name: str, has_views: bool, has_downloads: bool) -> str:
-    actor = viewer or "A visitor"
+def _build_notification_headline(viewer: str | None, target_type: str, target_name: str, has_views: bool, has_downloads: bool) -> str:
+    actor = viewer or _("A visitor")
     
     if target_type == 'dataroom':
         if has_views and has_downloads:
-            return f'{actor} viewed and downloaded files in your dataroom "{target_name}"'
+            return _('%(actor)s viewed and downloaded files in your dataroom "%(target_name)s"') % {
+                'actor': actor,
+                'target_name': target_name,
+            }
         if has_downloads:
-            return f'{actor} downloaded files in your dataroom "{target_name}"'
-        return f'{actor} visited your dataroom "{target_name}"'
+            return _('%(actor)s downloaded files in your dataroom "%(target_name)s"') % {
+                'actor': actor,
+                'target_name': target_name,
+            }
+        return _('%(actor)s visited your dataroom "%(target_name)s"') % {
+            'actor': actor,
+            'target_name': target_name,
+        }
     else:
         if has_views and has_downloads:
-            return f'{actor} viewed and downloaded the document "{target_name}"'
+            return _('%(actor)s viewed and downloaded the document "%(target_name)s"') % {
+                'actor': actor,
+                'target_name': target_name,
+            }
         if has_downloads:
-            return f'{actor} downloaded the document "{target_name}"'
-        return f'{actor} viewed the document "{target_name}"'
+            return _('%(actor)s downloaded the document "%(target_name)s"') % {
+                'actor': actor,
+                'target_name': target_name,
+            }
+        return _('%(actor)s viewed the document "%(target_name)s"') % {
+            'actor': actor,
+            'target_name': target_name,
+        }
+
+
+def _format_duration(seconds: int) -> str:
+    mins = seconds // 60
+    secs = seconds % 60
+    if mins > 0 and secs > 0:
+        return _("%(minutes)dm %(seconds)ds") % {'minutes': mins, 'seconds': secs}
+    if mins > 0:
+        return _("%(minutes)dm") % {'minutes': mins}
+    return _("%(seconds)ds") % {'seconds': secs}
 
 
 def _get_session_completion_stats(view_session_id: str, since_datetime=None) -> dict:
@@ -82,14 +111,14 @@ def _get_session_completion_stats(view_session_id: str, since_datetime=None) -> 
         completion = int((unique_pages / num_pages) * 100) if num_pages > 0 else 0
         completion = min(completion, 100)
         
-        # Format total reading duration into human-readable minutes and seconds
-        if total_duration >= 60:
-            duration_str = f"{total_duration // 60}m {total_duration % 60}s"
-        else:
-            duration_str = f"{total_duration}s"
+        # Format total reading duration into localized human-readable minutes and seconds
+        duration_str = _format_duration(total_duration)
             
         if num_pages > 1:
-            info = f"{duration_str}, {completion}% read"
+            info = _("%(duration_str)s, %(completion)s%% read") % {
+                'duration_str': duration_str,
+                'completion': completion,
+            }
         else:
             info = f"{duration_str}"
         stats[doc_id] = {'name': doc_name, 'value': info}
@@ -118,182 +147,194 @@ def _build_show_details_url(payload: dict) -> str:
 
 def _send_coalesced_session_email(owner, recipient_email: str, view_session_id: str, pending_deliveries: list, first_delivery: AutomationDelivery):
     payload = first_delivery.payload or {}
+    owner_lang = getattr(owner, 'language', 'en') or 'en'
 
-    # Build coalesced context
-    dr_name = payload.get('dataroom_name')
-    doc_name = payload.get('document_name')
-    target_name = dr_name or doc_name or "Shared Item"
-    target_type = 'dataroom' if dr_name else 'document'
+    with translation_override(owner_lang):
+        # Build coalesced context
+        dr_name = payload.get('dataroom_name')
+        doc_name = payload.get('document_name')
+        target_name = dr_name or doc_name or _("Shared Item")
+        target_type = 'dataroom' if dr_name else 'document'
 
-    viewer_email = payload.get('viewer_email') or "A visitor"
+        viewer_email = payload.get('viewer_email') or _("A visitor")
 
-    has_views = any(d.event_type in ('document_viewed', 'dataroom_opened') for d in pending_deliveries)
-    has_downloads = any(d.event_type == 'document_downloaded' for d in pending_deliveries)
+        has_views = any(d.event_type in ('document_viewed', 'dataroom_opened') for d in pending_deliveries)
+        has_downloads = any(d.event_type == 'document_downloaded' for d in pending_deliveries)
 
-    headline = _build_notification_headline(viewer_email, target_type, target_name, has_views, has_downloads)
-    subject = headline
+        headline = _build_notification_headline(payload.get('viewer_email'), target_type, target_name, has_views, has_downloads)
+        subject = headline
 
-    # Fetch detailed file view stats (duration and completion rates).
-    # To isolate statistics only to the current active segment window (and exclude older
-    # activity already alerted on), we find the creation time of the earliest delivery
-    # in the current coalesced batch and apply a tiny 5-second buffer.
-    earliest_delivery = min(pending_deliveries, key=lambda d: d.created_at)
-    since_datetime = earliest_delivery.created_at - timedelta(seconds=5)
-    stats = _get_session_completion_stats(view_session_id, since_datetime=since_datetime)
-    activity_stats_html = list(stats.values())
-    activity_stats_txt = [f"- {item['name']}: {item['value']}" for item in stats.values()]
+        # Fetch detailed file view stats (duration and completion rates).
+        # To isolate statistics only to the current active segment window (and exclude older
+        # activity already alerted on), we find the creation time of the earliest delivery
+        # in the current coalesced batch and apply a tiny 5-second buffer.
+        earliest_delivery = min(pending_deliveries, key=lambda d: d.created_at)
+        since_datetime = earliest_delivery.created_at - timedelta(seconds=5)
+        stats = _get_session_completion_stats(view_session_id, since_datetime=since_datetime)
+        activity_stats_html = list(stats.values())
+        activity_stats_txt = [f"- {item['name']}: {item['value']}" for item in stats.values()]
 
-    event_dt_str = payload.get('event_datetime')
-    viewed_at = None
-    if event_dt_str:
+        event_dt_str = payload.get('event_datetime')
+        viewed_at = None
+        if event_dt_str:
+            try:
+                viewed_at = parse_datetime(event_dt_str)
+            except Exception:
+                pass
+        if not viewed_at:
+            viewed_at = first_delivery.created_at
+
+        if timezone.is_naive(viewed_at):
+            viewed_at = timezone.make_aware(viewed_at, timezone.utc)
+
+        city = payload.get('visitor_city')
+        country = payload.get('visitor_country')
+        location = f"{city}, {country}" if city and country else _("Unknown Location")
+
+        # Query ViewSession to resolve visitor OS and browser metadata
+        os_name, browser_name = _("Unknown OS"), _("Unknown Browser")
+        if view_session_id:
+            try:
+                vs = ViewSession.objects.filter(id=view_session_id).first()
+                if vs and vs.user_agent:
+                    parsed_os, parsed_browser = parse_user_agent(vs.user_agent)
+                    os_name = parsed_os or _("Unknown OS")
+                    browser_name = parsed_browser or _("Unknown Browser")
+            except Exception as e:
+                logger.warning('Failed to query ViewSession for user agent: %s', e)
+
+        context = {
+            'owner_name': owner.name or '',
+            'target_name': target_name,
+            'headline': headline,
+            'viewer_email': viewer_email,
+            'viewed_at': viewed_at,
+            'ip_address': payload.get('visitor_ip'),
+            'location': location,
+            'os': os_name,
+            'browser': browser_name,
+            'activity_stats': activity_stats_html,
+            'activity_stats_txt': activity_stats_txt,
+            'show_details_url': _build_show_details_url(payload) if view_session_id else None,
+        }
+
+        # Send coalesced email
         try:
-            viewed_at = parse_datetime(event_dt_str)
-        except Exception:
-            pass
-    if not viewed_at:
-        viewed_at = first_delivery.created_at
+            try:
+                display_timezone = ZoneInfo(settings.DISPLAY_TIME_ZONE)
+            except Exception:
+                display_timezone = ZoneInfo('UTC')
 
-    if timezone.is_naive(viewed_at):
-        viewed_at = timezone.make_aware(viewed_at, timezone.utc)
+            with timezone.override(display_timezone):
+                text_content = render_to_string('sharelinks/view_notification_email.txt', context)
+                html_content = render_to_string('sharelinks/view_notification_email.html', context)
 
-    city = payload.get('visitor_city')
-    country = payload.get('visitor_country')
-    location = f"{city}, {country}" if city and country else "Unknown Location"
-
-    # Query ViewSession to resolve visitor OS and browser metadata
-    os_name, browser_name = "Unknown OS", "Unknown Browser"
-    if view_session_id:
-        try:
-            vs = ViewSession.objects.filter(id=view_session_id).first()
-            if vs and vs.user_agent:
-                os_name, browser_name = parse_user_agent(vs.user_agent)
+            send_mail(
+                subject=subject,
+                message=text_content,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[recipient_email],
+                fail_silently=False,
+                html_message=html_content
+            )
+            logger.info('Sent coalesced view notification email to %s for session %s.', recipient_email, view_session_id)
+            
+            # Mark successful deliveries atomically
+            with transaction.atomic():
+                for d in pending_deliveries:
+                    d.attempt_count += 1
+                    d.status = AutomationDelivery.Status.SUCCESS
+                    d.response_code = 200
+                    d.response_body_excerpt = f'Sent email successfully to {recipient_email}'
+                    d.delivered_at = timezone.now()
+                    d.next_retry_at = None
+                    d.save(update_fields=['attempt_count', 'status', 'response_code', 'response_body_excerpt', 'delivered_at', 'next_retry_at', 'updated_at'])
         except Exception as e:
-            logger.warning('Failed to query ViewSession for user agent: %s', e)
-
-    context = {
-        'owner_name': owner.name or '',
-        'target_name': target_name,
-        'headline': headline,
-        'viewer_email': viewer_email,
-        'viewed_at': viewed_at,
-        'ip_address': payload.get('visitor_ip'),
-        'location': location,
-        'os': os_name,
-        'browser': browser_name,
-        'activity_stats': activity_stats_html,
-        'activity_stats_txt': activity_stats_txt,
-        'show_details_url': _build_show_details_url(payload) if view_session_id else None,
-    }
-
-    # Send coalesced email
-    try:
-        try:
-            display_timezone = ZoneInfo(settings.DISPLAY_TIME_ZONE)
-        except Exception:
-            display_timezone = ZoneInfo('UTC')
-
-        with timezone.override(display_timezone):
-            text_content = render_to_string('sharelinks/view_notification_email.txt', context)
-            html_content = render_to_string('sharelinks/view_notification_email.html', context)
-
-        send_mail(
-            subject=subject,
-            message=text_content,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[recipient_email],
-            fail_silently=False,
-            html_message=html_content
-        )
-        logger.info('Sent coalesced view notification email to %s for session %s.', recipient_email, view_session_id)
-        
-        # Mark successful deliveries atomically
-        with transaction.atomic():
-            for d in pending_deliveries:
-                d.attempt_count += 1
-                d.status = AutomationDelivery.Status.SUCCESS
-                d.response_code = 200
-                d.response_body_excerpt = f'Sent email successfully to {recipient_email}'
-                d.delivered_at = timezone.now()
-                d.next_retry_at = None
-                d.save(update_fields=['attempt_count', 'status', 'response_code', 'response_body_excerpt', 'delivered_at', 'next_retry_at', 'updated_at'])
-    except Exception as e:
-        logger.error('Failed to send coalesced email notification for session %s: %s', view_session_id, e)
-        # Revert PROCESSING status on failure so it can retry
-        with transaction.atomic():
-            for d in pending_deliveries:
-                tasks._mark_failure_and_retry(d, f'Failed to send email: {e}')
+            logger.error('Failed to send coalesced email notification for session %s: %s', view_session_id, e)
+            # Revert PROCESSING status on failure so it can retry
+            with transaction.atomic():
+                for d in pending_deliveries:
+                    tasks._mark_failure_and_retry(d, f'Failed to send email: {e}')
 
 
 def _send_standard_fallback_email(owner, recipient_email: str, delivery: AutomationDelivery):
     payload = delivery.payload or {}
-    target = tasks._target_description(payload)
-    event_type = delivery.event_type
-    event_text = tasks._build_event_sentence(event_type, payload)
-    viewer_email = payload.get('viewer_email') or "Anonymous"
+    owner_lang = getattr(owner, 'language', 'en') or 'en'
 
-    # Determine standard fallback headline
-    headline = f"Activity alert: {target}"
-    if event_type == 'file_request_uploaded':
-        uploader = tasks._display_actor(payload.get('uploaded_by_name'), payload.get('uploaded_by_email'), fallback="Someone")
-        req_name = payload.get('file_request_name') or "file request"
-        headline = f'{uploader} uploaded a file to your file request "{req_name}"'
-    elif event_type == 'file_request_malware_detected':
-        headline = 'Malware detected in your file request'
-    elif event_type == 'file_request_scan_failed':
-        headline = 'Malware scanning failed'
+    with translation_override(owner_lang):
+        target = tasks._target_description(payload)
+        event_type = delivery.event_type
+        event_text = tasks._build_event_sentence(event_type, payload)
+        viewer_email = payload.get('viewer_email') or _("Anonymous")
 
-    subject = headline
-    
-    viewed_at = delivery.created_at
-    if timezone.is_naive(viewed_at):
-        viewed_at = timezone.make_aware(viewed_at, timezone.utc)
+        # Determine standard fallback headline
+        headline = _("Activity alert: %(target)s") % {'target': target}
+        if event_type == 'file_request_uploaded':
+            uploader = tasks._display_actor(payload.get('uploaded_by_name'), payload.get('uploaded_by_email'), fallback=_("Someone"))
+            req_name = payload.get('file_request_name') or _("file request")
+            headline = _('%(uploader)s uploaded a file to your file request "%(req_name)s"') % {
+                'uploader': uploader,
+                'req_name': req_name,
+            }
+        elif event_type == 'file_request_malware_detected':
+            headline = _('Malware detected in your file request')
+        elif event_type == 'file_request_scan_failed':
+            headline = _('Malware scanning failed')
 
-    user_agent = payload.get('user_agent') or ''
-    os_name, browser_name = parse_user_agent(user_agent)
+        subject = headline
+        
+        viewed_at = delivery.created_at
+        if timezone.is_naive(viewed_at):
+            viewed_at = timezone.make_aware(viewed_at, timezone.utc)
 
-    city = payload.get('visitor_city')
-    country = payload.get('visitor_country')
-    location = f"{city}, {country}" if city and country else "Unknown Location"
+        user_agent = payload.get('user_agent') or ''
+        os_name, browser_name = parse_user_agent(user_agent)
+        os_name = os_name or _("Unknown OS")
+        browser_name = browser_name or _("Unknown Browser")
 
-    context = {
-        'owner_name': owner.name or '',
-        'target_name': target,
-        'headline': headline,
-        'event_text': event_text,
-        'viewer_email': viewer_email,
-        'viewed_at': viewed_at,
-        'ip_address': payload.get('visitor_ip'),
-        'location': location,
-        'os': os_name,
-        'browser': browser_name,
-        'activity_stats': [],
-        'activity_stats_txt': [],
-        'show_details_url': _build_show_details_url(payload),
-    }
+        city = payload.get('visitor_city')
+        country = payload.get('visitor_country')
+        location = f"{city}, {country}" if city and country else _("Unknown Location")
 
-    try:
+        context = {
+            'owner_name': owner.name or '',
+            'target_name': target,
+            'headline': headline,
+            'event_text': event_text,
+            'viewer_email': viewer_email,
+            'viewed_at': viewed_at,
+            'ip_address': payload.get('visitor_ip'),
+            'location': location,
+            'os': os_name,
+            'browser': browser_name,
+            'activity_stats': [],
+            'activity_stats_txt': [],
+            'show_details_url': _build_show_details_url(payload),
+        }
+
         try:
-            display_timezone = ZoneInfo(settings.DISPLAY_TIME_ZONE)
-        except Exception:
-            display_timezone = ZoneInfo('UTC')
+            try:
+                display_timezone = ZoneInfo(settings.DISPLAY_TIME_ZONE)
+            except Exception:
+                display_timezone = ZoneInfo('UTC')
 
-        with timezone.override(display_timezone):
-            text_content = render_to_string('sharelinks/view_notification_email.txt', context)
-            html_content = render_to_string('sharelinks/view_notification_email.html', context)
+            with timezone.override(display_timezone):
+                text_content = render_to_string('sharelinks/view_notification_email.txt', context)
+                html_content = render_to_string('sharelinks/view_notification_email.html', context)
 
-        send_mail(
-            subject=subject,
-            message=text_content,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[recipient_email],
-            fail_silently=False,
-            html_message=html_content
-        )
-        logger.info('Sent notification email to %s for delivery %s.', recipient_email, delivery.id)
-        tasks._mark_success_direct(delivery, f'Sent email successfully to {recipient_email}')
-    except Exception as e:
-        logger.error('Failed to send email notification for delivery %s: %s', delivery.id, e)
-        tasks._mark_failure_and_retry(delivery, f'Failed to send email: {e}')
+            send_mail(
+                subject=subject,
+                message=text_content,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[recipient_email],
+                fail_silently=False,
+                html_message=html_content
+            )
+            logger.info('Sent notification email to %s for delivery %s.', recipient_email, delivery.id)
+            tasks._mark_success_direct(delivery, f'Sent email successfully to {recipient_email}')
+        except Exception as e:
+            logger.error('Failed to send email notification for delivery %s: %s', delivery.id, e)
+            tasks._mark_failure_and_retry(delivery, f'Failed to send email: {e}')
 
 
 def handle_email_delivery(delivery: AutomationDelivery):

--- a/backend/automations/tasks.py
+++ b/backend/automations/tasks.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils.dateparse import parse_datetime
 from django.utils import timezone
+from django.utils.translation import gettext as _, override as translation_override
 
 from .models import AutomationDelivery
 from .services import dispatch_automation_event
@@ -47,7 +48,7 @@ def _build_headers(delivery: AutomationDelivery, request_payload: dict) -> dict:
     return headers
 
 
-def _display_actor(name: str | None, email: str | None, fallback: str = 'Anonymous') -> str:
+def _display_actor(name: str | None, email: str | None, fallback: str | None = None) -> str:
     name = (name or '').strip()
     email = (email or '').strip()
     if name and email:
@@ -56,7 +57,7 @@ def _display_actor(name: str | None, email: str | None, fallback: str = 'Anonymo
         return email
     if name:
         return name
-    return fallback
+    return fallback if fallback is not None else _('Anonymous')
 
 
 def _target_description(payload: dict) -> str:
@@ -66,17 +67,27 @@ def _target_description(payload: dict) -> str:
 
     if document_name:
         if dataroom_folder_name and dataroom_name:
-            return f'document "{document_name}" in folder "{dataroom_folder_name}" in dataroom "{dataroom_name}"'
+            return _('document "%(document_name)s" in folder "%(folder_name)s" in dataroom "%(dataroom_name)s"') % {
+                'document_name': document_name,
+                'folder_name': dataroom_folder_name,
+                'dataroom_name': dataroom_name,
+            }
         if dataroom_name:
-            return f'document "{document_name}" in dataroom "{dataroom_name}"'
-        return f'document "{document_name}"'
+            return _('document "%(document_name)s" in dataroom "%(dataroom_name)s"') % {
+                'document_name': document_name,
+                'dataroom_name': dataroom_name,
+            }
+        return _('document "%(document_name)s"') % {'document_name': document_name}
     if dataroom_folder_name and dataroom_name:
-        return f'folder "{dataroom_folder_name}" in dataroom "{dataroom_name}"'
+        return _('folder "%(folder_name)s" in dataroom "%(dataroom_name)s"') % {
+            'folder_name': dataroom_folder_name,
+            'dataroom_name': dataroom_name,
+        }
     if dataroom_folder_name:
-        return f'folder "{dataroom_folder_name}"'
+        return _('folder "%(folder_name)s"') % {'folder_name': dataroom_folder_name}
     if dataroom_name:
-        return f'dataroom "{dataroom_name}"'
-    return 'item'
+        return _('dataroom "%(dataroom_name)s"') % {'dataroom_name': dataroom_name}
+    return _('item')
 
 
 def _format_event_time(value: str | None) -> str | None:
@@ -116,9 +127,9 @@ def _append_event_details(message: str, payload: dict) -> str:
     location = _approximate_location(payload)
 
     if event_time:
-        details.append(f'Time: {event_time}')
+        details.append(f'{_("Time:")} {event_time}')
     if location:
-        details.append(f'Approximate location: {location}')
+        details.append(f'{_("Approximate location:")} {location}')
 
     if not details:
         return message
@@ -137,7 +148,7 @@ def _append_custom_field_summary(message: str, payload: dict) -> str:
 
     remaining_count = len(values) - len(lines)
     if remaining_count > 0:
-        lines.append(f'Additional fields: {remaining_count}')
+        lines.append(_('Additional fields: %(count)s') % {'count': remaining_count})
 
     return f'{message}\n' + '\n'.join(lines)
 
@@ -147,53 +158,130 @@ def _build_event_sentence(event_type: str, payload: dict) -> str:
     target = _target_description(payload)
 
     if event_type == 'document_viewed':
-        return f'Your shared {target} was viewed by {viewer}.'
+        return _('Your shared %(target)s was viewed by %(viewer)s.') % {
+            'target': target,
+            'viewer': viewer,
+        }
 
     if event_type == 'dataroom_opened':
-        return f'Your shared {target} was opened by {viewer}.'
+        return _('Your shared %(target)s was opened by %(viewer)s.') % {
+            'target': target,
+            'viewer': viewer,
+        }
 
     if event_type == 'document_downloaded':
-        return f'Your shared {target} was downloaded by {viewer}.'
+        return _('Your shared %(target)s was downloaded by %(viewer)s.') % {
+            'target': target,
+            'viewer': viewer,
+        }
 
     if event_type == 'email_identified':
-        return f'{viewer} identified their email address for your shared {target}.'
+        return _('%(viewer)s identified their email address for your shared %(target)s.') % {
+            'viewer': viewer,
+            'target': target,
+        }
 
-    thread_subject = payload.get('thread_subject') or 'Q&A thread'
+    thread_subject = payload.get('thread_subject') or _('Q&A thread')
     sender_type = payload.get('sender_type') or 'user'
+    actor = viewer if sender_type == "viewer" else _("A team member")
 
     if event_type == 'qna_thread_created':
-        return f'{viewer if sender_type == "viewer" else "A team member"} opened Q&A thread "{thread_subject}" on your shared {target}.'
+        return _('%(actor)s opened Q&A thread "%(thread_subject)s" on your shared %(target)s.') % {
+            'actor': actor,
+            'thread_subject': thread_subject,
+            'target': target,
+        }
 
     if event_type == 'qna_message_created':
-        return f'{viewer if sender_type == "viewer" else "A team member"} replied to Q&A thread "{thread_subject}" on your shared {target}.'
+        return _('%(actor)s replied to Q&A thread "%(thread_subject)s" on your shared %(target)s.') % {
+            'actor': actor,
+            'thread_subject': thread_subject,
+            'target': target,
+        }
 
     if event_type == 'qna_thread_closed':
-        return f'Q&A thread "{thread_subject}" was closed on your shared {target}.'
+        return _('Q&A thread "%(thread_subject)s" was closed on your shared %(target)s.') % {
+            'thread_subject': thread_subject,
+            'target': target,
+        }
 
     if event_type == 'qna_thread_reopened':
-        return f'Q&A thread "{thread_subject}" was reopened on your shared {target}.'
+        return _('Q&A thread "%(thread_subject)s" was reopened on your shared %(target)s.') % {
+            'thread_subject': thread_subject,
+            'target': target,
+        }
 
     uploader = _display_actor(
         payload.get('uploaded_by_name'),
         payload.get('uploaded_by_email'),
-        fallback='Unknown uploader',
+        fallback=_('Unknown uploader'),
     )
     uploaded_file_name = payload.get('uploaded_file_name')
     file_request_name = payload.get('file_request_name') or payload.get('file_request_slug')
-    file_request_text = f' to file request "{file_request_name}"' if file_request_name else ''
-    file_text = f' "{uploaded_file_name}"' if uploaded_file_name else ''
 
     if event_type == 'file_request_uploaded':
-        message = f'{uploader} uploaded{file_text}{file_request_text}.'
+        if uploaded_file_name and file_request_name:
+            message = _('%(uploader)s uploaded "%(file_name)s" to file request "%(req_name)s".') % {
+                'uploader': uploader,
+                'file_name': uploaded_file_name,
+                'req_name': file_request_name,
+            }
+        elif uploaded_file_name:
+            message = _('%(uploader)s uploaded "%(file_name)s".') % {
+                'uploader': uploader,
+                'file_name': uploaded_file_name,
+            }
+        elif file_request_name:
+            message = _('%(uploader)s uploaded to file request "%(req_name)s".') % {
+                'uploader': uploader,
+                'req_name': file_request_name,
+            }
+        else:
+            message = _('%(uploader)s uploaded a file.') % {'uploader': uploader}
         return _append_custom_field_summary(message, payload)
 
     if event_type == 'file_request_malware_detected':
-        return f'Malware was detected in uploaded file{file_text}{file_request_text} from {uploader}.'
+        if uploaded_file_name and file_request_name:
+            return _('Malware was detected in uploaded file "%(file_name)s" to file request "%(req_name)s" from %(uploader)s.') % {
+                'file_name': uploaded_file_name,
+                'req_name': file_request_name,
+                'uploader': uploader,
+            }
+        elif uploaded_file_name:
+            return _('Malware was detected in uploaded file "%(file_name)s" from %(uploader)s.') % {
+                'file_name': uploaded_file_name,
+                'uploader': uploader,
+            }
+        elif file_request_name:
+            return _('Malware was detected in uploaded file to file request "%(req_name)s" from %(uploader)s.') % {
+                'req_name': file_request_name,
+                'uploader': uploader,
+            }
+        return _('Malware was detected in uploaded file from %(uploader)s.') % {'uploader': uploader}
 
     if event_type == 'file_request_scan_failed':
-        return f'Malware scanning failed for uploaded file{file_text}{file_request_text} from {uploader}.'
+        if uploaded_file_name and file_request_name:
+            return _('Malware scanning failed for uploaded file "%(file_name)s" to file request "%(req_name)s" from %(uploader)s.') % {
+                'file_name': uploaded_file_name,
+                'req_name': file_request_name,
+                'uploader': uploader,
+            }
+        elif uploaded_file_name:
+            return _('Malware scanning failed for uploaded file "%(file_name)s" from %(uploader)s.') % {
+                'file_name': uploaded_file_name,
+                'uploader': uploader,
+            }
+        elif file_request_name:
+            return _('Malware scanning failed for uploaded file to file request "%(req_name)s" from %(uploader)s.') % {
+                'req_name': file_request_name,
+                'uploader': uploader,
+            }
+        return _('Malware scanning failed for uploaded file from %(uploader)s.') % {'uploader': uploader}
 
-    return f'Coneshare automation event "{event_type}" was triggered for {target}.'
+    return _('Coneshare automation event "%(event_type)s" was triggered for %(target)s.') % {
+        'event_type': event_type,
+        'target': target,
+    }
 
 
 def _build_event_text(delivery: AutomationDelivery) -> str:
@@ -331,7 +419,10 @@ def deliver_automation_delivery_task(delivery_id: str):
         handle_email_delivery(delivery)
         return
 
-    request_payload = _build_request_payload(delivery)
+    owner = delivery.rule.created_by
+    owner_lang = getattr(owner, 'language', 'en') or 'en'
+    with translation_override(owner_lang):
+        request_payload = _build_request_payload(delivery)
     logger.info(
         'Automation delivery prepared: delivery_id=%s destination_type=%s method=%s url=%s payload_keys=%s has_text=%s',
         delivery_id,

--- a/backend/locale/ru/LC_MESSAGES/django.po
+++ b/backend/locale/ru/LC_MESSAGES/django.po
@@ -119,6 +119,9 @@ msgstr "IP-адрес:"
 msgid "Approximate Location:"
 msgstr "Примерное местоположение:"
 
+msgid "Approximate location:"
+msgstr "Примерное местоположение:"
+
 msgid "Location:"
 msgstr "Местоположение:"
 
@@ -157,3 +160,162 @@ msgstr "Документ с таким именем уже существует 
 
 msgid "A folder with this name already exists in this location."
 msgstr "Папка с таким именем уже существует в этой папке."
+
+msgid "A visitor"
+msgstr "Посетитель"
+
+msgid "Shared Item"
+msgstr "Общий элемент"
+
+msgid "Unknown OS"
+msgstr "Неизвестная ОС"
+
+msgid "Unknown Browser"
+msgstr "Неизвестный браузер"
+
+msgid "%(actor)s viewed and downloaded files in your dataroom \"%(target_name)s\""
+msgstr "%(actor)s просмотрел(а) и скачал(а) файлы в вашем датаруме «%(target_name)s»"
+
+msgid "%(actor)s downloaded files in your dataroom \"%(target_name)s\""
+msgstr "%(actor)s скачал(а) файлы в вашем датаруме «%(target_name)s»"
+
+msgid "%(actor)s visited your dataroom \"%(target_name)s\""
+msgstr "%(actor)s посетил(а) ваш датарум «%(target_name)s»"
+
+msgid "%(actor)s viewed and downloaded the document \"%(target_name)s\""
+msgstr "%(actor)s просмотрел(а) и скачал(а) документ «%(target_name)s»"
+
+msgid "%(actor)s downloaded the document \"%(target_name)s\""
+msgstr "%(actor)s скачал(а) документ «%(target_name)s»"
+
+msgid "%(actor)s viewed the document \"%(target_name)s\""
+msgstr "%(actor)s просмотрел(а) документ «%(target_name)s»"
+
+msgid "%(duration_str)s, %(completion)s%% read"
+msgstr "%(duration_str)s, прочитано %(completion)s%%"
+
+msgid "Activity alert: %(target)s"
+msgstr "Оповещение об активности: %(target)s"
+
+msgid "%(uploader)s uploaded a file to your file request \"%(req_name)s\""
+msgstr "%(uploader)s загрузил(а) файл по вашему запросу «%(req_name)s»"
+
+msgid "Malware detected in your file request"
+msgstr "В вашем запросе файлов обнаружено вредоносное ПО"
+
+msgid "Malware scanning failed"
+msgstr "Сбой сканирования на вредоносное ПО"
+
+msgid "Someone"
+msgstr "Кто-то"
+
+msgid "file request"
+msgstr "запрос файлов"
+
+msgid "document \"%(document_name)s\" in folder \"%(folder_name)s\" in dataroom \"%(dataroom_name)s\""
+msgstr "документ «%(document_name)s» в папке «%(folder_name)s» в датаруме «%(dataroom_name)s»"
+
+msgid "document \"%(document_name)s\" in dataroom \"%(dataroom_name)s\""
+msgstr "документ «%(document_name)s» в датаруме «%(dataroom_name)s»"
+
+msgid "document \"%(document_name)s\""
+msgstr "документ «%(document_name)s»"
+
+msgid "folder \"%(folder_name)s\" in dataroom \"%(dataroom_name)s\""
+msgstr "папка «%(folder_name)s» в датаруме «%(dataroom_name)s»"
+
+msgid "folder \"%(folder_name)s\""
+msgstr "папка «%(folder_name)s»"
+
+msgid "dataroom \"%(dataroom_name)s\""
+msgstr "датарум «%(dataroom_name)s»"
+
+msgid "item"
+msgstr "элемент"
+
+msgid "Additional fields: %(count)s"
+msgstr "Дополнительные поля: %(count)s"
+
+msgid "Your shared %(target)s was viewed by %(viewer)s."
+msgstr "Ваш общий %(target)s был просмотрен пользователем %(viewer)s."
+
+msgid "Your shared %(target)s was opened by %(viewer)s."
+msgstr "Ваш общий %(target)s был открыт пользователем %(viewer)s."
+
+msgid "Your shared %(target)s was downloaded by %(viewer)s."
+msgstr "Ваш общий %(target)s был скачан пользователем %(viewer)s."
+
+msgid "%(viewer)s identified their email address for your shared %(target)s."
+msgstr "%(viewer)s указал(а) свой email для вашего общего %(target)s."
+
+msgid "Q&A thread"
+msgstr "обсуждение вопросов и ответов"
+
+msgid "A team member"
+msgstr "Участник команды"
+
+msgid "%(actor)s opened Q&A thread \"%(thread_subject)s\" on your shared %(target)s."
+msgstr "%(actor)s создал(а) обсуждение «%(thread_subject)s» в вашем общем %(target)s."
+
+msgid "%(actor)s replied to Q&A thread \"%(thread_subject)s\" on your shared %(target)s."
+msgstr "%(actor)s ответил(а) в обсуждении «%(thread_subject)s» в вашем общем %(target)s."
+
+msgid "Q&A thread \"%(thread_subject)s\" was closed on your shared %(target)s."
+msgstr "Обсуждение «%(thread_subject)s» в вашем общем %(target)s было закрыто."
+
+msgid "Q&A thread \"%(thread_subject)s\" was reopened on your shared %(target)s."
+msgstr "Обсуждение «%(thread_subject)s» в вашем общем %(target)s было открыто заново."
+
+msgid "Unknown uploader"
+msgstr "Неизвестный автор загрузки"
+
+msgid "%(uploader)s uploaded \"%(file_name)s\" to file request \"%(req_name)s\"."
+msgstr "%(uploader)s загрузил(а) «%(file_name)s» по запросу файлов «%(req_name)s»."
+
+msgid "%(uploader)s uploaded \"%(file_name)s\"."
+msgstr "%(uploader)s загрузил(а) «%(file_name)s»."
+
+msgid "%(uploader)s uploaded to file request \"%(req_name)s\"."
+msgstr "%(uploader)s выполнил(а) загрузку по запросу файлов «%(req_name)s»."
+
+msgid "%(uploader)s uploaded a file."
+msgstr "%(uploader)s загрузил(а) файл."
+
+msgid "Malware was detected in uploaded file \"%(file_name)s\" to file request \"%(req_name)s\" from %(uploader)s."
+msgstr "В файле «%(file_name)s», загруженном %(uploader)s по запросу «%(req_name)s», обнаружено вредоносное ПО."
+
+msgid "Malware was detected in uploaded file \"%(file_name)s\" from %(uploader)s."
+msgstr "В файле «%(file_name)s», загруженном %(uploader)s, обнаружено вредоносное ПО."
+
+msgid "Malware was detected in uploaded file to file request \"%(req_name)s\" from %(uploader)s."
+msgstr "В файле, загруженном %(uploader)s по запросу «%(req_name)s», обнаружено вредоносное ПО."
+
+msgid "Malware was detected in uploaded file from %(uploader)s."
+msgstr "В файле, загруженном %(uploader)s, обнаружено вредоносное ПО."
+
+msgid "Malware scanning failed for uploaded file \"%(file_name)s\" to file request \"%(req_name)s\" from %(uploader)s."
+msgstr "Сбой сканирования на вредоносное ПО для файла «%(file_name)s», загруженного %(uploader)s по запросу «%(req_name)s»."
+
+msgid "Malware scanning failed for uploaded file \"%(file_name)s\" from %(uploader)s."
+msgstr "Сбой сканирования на вредоносное ПО для файла «%(file_name)s», загруженного %(uploader)s."
+
+msgid "Malware scanning failed for uploaded file to file request \"%(req_name)s\" from %(uploader)s."
+msgstr "Сбой сканирования на вредоносное ПО для файла, загруженного %(uploader)s по запросу «%(req_name)s»."
+
+msgid "Malware scanning failed for uploaded file from %(uploader)s."
+msgstr "Сбой сканирования на вредоносное ПО для файла, загруженного %(uploader)s."
+
+msgid "Coneshare automation event \"%(event_type)s\" was triggered for %(target)s."
+msgstr "Для %(target)s сработало событие автоматизации Coneshare «%(event_type)s»."
+
+msgid "%(minutes)dm %(seconds)ds"
+msgstr "%(minutes)d мин %(seconds)d с"
+
+msgid "%(minutes)dm"
+msgstr "%(minutes)d мин"
+
+msgid "%(seconds)ds"
+msgstr "%(seconds)d с"
+
+
+

--- a/backend/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/backend/locale/zh_Hans/LC_MESSAGES/django.po
@@ -119,6 +119,9 @@ msgstr "IP 地址："
 msgid "Approximate Location:"
 msgstr "大致位置："
 
+msgid "Approximate location:"
+msgstr "大致位置："
+
 msgid "Location:"
 msgstr "地理位置："
 
@@ -157,3 +160,162 @@ msgstr "该位置已存在同名文档。"
 
 msgid "A folder with this name already exists in this location."
 msgstr "该位置已存在同名文件夹。"
+
+msgid "A visitor"
+msgstr "访客"
+
+msgid "Shared Item"
+msgstr "分享项目"
+
+msgid "Unknown OS"
+msgstr "未知操作系统"
+
+msgid "Unknown Browser"
+msgstr "未知浏览器"
+
+msgid "%(actor)s viewed and downloaded files in your dataroom \"%(target_name)s\""
+msgstr "%(actor)s 查看并下载了您资料室“%(target_name)s”中的文件"
+
+msgid "%(actor)s downloaded files in your dataroom \"%(target_name)s\""
+msgstr "%(actor)s 下载了您资料室“%(target_name)s”中的文件"
+
+msgid "%(actor)s visited your dataroom \"%(target_name)s\""
+msgstr "%(actor)s 访问了您的资料室“%(target_name)s”"
+
+msgid "%(actor)s viewed and downloaded the document \"%(target_name)s\""
+msgstr "%(actor)s 查看并下载了文档“%(target_name)s”"
+
+msgid "%(actor)s downloaded the document \"%(target_name)s\""
+msgstr "%(actor)s 下载了文档“%(target_name)s”"
+
+msgid "%(actor)s viewed the document \"%(target_name)s\""
+msgstr "%(actor)s 查看了文档“%(target_name)s”"
+
+msgid "%(duration_str)s, %(completion)s%% read"
+msgstr "%(duration_str)s，已阅读 %(completion)s%%"
+
+msgid "Activity alert: %(target)s"
+msgstr "活动提醒：%(target)s"
+
+msgid "%(uploader)s uploaded a file to your file request \"%(req_name)s\""
+msgstr "%(uploader)s 向您的文件收集“%(req_name)s”上传了文件"
+
+msgid "Malware detected in your file request"
+msgstr "您的文件收集中检测到恶意软件"
+
+msgid "Malware scanning failed"
+msgstr "恶意软件扫描失败"
+
+msgid "Someone"
+msgstr "有人"
+
+msgid "file request"
+msgstr "文件收集"
+
+msgid "document \"%(document_name)s\" in folder \"%(folder_name)s\" in dataroom \"%(dataroom_name)s\""
+msgstr "资料室“%(dataroom_name)s”中文件夹“%(folder_name)s”下的文档“%(document_name)s”"
+
+msgid "document \"%(document_name)s\" in dataroom \"%(dataroom_name)s\""
+msgstr "资料室“%(dataroom_name)s”中的文档“%(document_name)s”"
+
+msgid "document \"%(document_name)s\""
+msgstr "文档“%(document_name)s”"
+
+msgid "folder \"%(folder_name)s\" in dataroom \"%(dataroom_name)s\""
+msgstr "资料室“%(dataroom_name)s”中的文件夹“%(folder_name)s”"
+
+msgid "folder \"%(folder_name)s\""
+msgstr "文件夹“%(folder_name)s”"
+
+msgid "dataroom \"%(dataroom_name)s\""
+msgstr "资料室“%(dataroom_name)s”"
+
+msgid "item"
+msgstr "项目"
+
+msgid "Additional fields: %(count)s"
+msgstr "附加字段：%(count)s"
+
+msgid "Your shared %(target)s was viewed by %(viewer)s."
+msgstr "您分享的%(target)s已被%(viewer)s查看。"
+
+msgid "Your shared %(target)s was opened by %(viewer)s."
+msgstr "您分享的%(target)s已被%(viewer)s打开。"
+
+msgid "Your shared %(target)s was downloaded by %(viewer)s."
+msgstr "您分享的%(target)s已被%(viewer)s下载。"
+
+msgid "%(viewer)s identified their email address for your shared %(target)s."
+msgstr "%(viewer)s 为您分享的%(target)s验证了邮箱地址。"
+
+msgid "Q&A thread"
+msgstr "问答主题"
+
+msgid "A team member"
+msgstr "团队成员"
+
+msgid "%(actor)s opened Q&A thread \"%(thread_subject)s\" on your shared %(target)s."
+msgstr "%(actor)s 在您分享的%(target)s中开启了问答主题“%(thread_subject)s”。"
+
+msgid "%(actor)s replied to Q&A thread \"%(thread_subject)s\" on your shared %(target)s."
+msgstr "%(actor)s 在您分享的%(target)s中回复了问答主题“%(thread_subject)s”。"
+
+msgid "Q&A thread \"%(thread_subject)s\" was closed on your shared %(target)s."
+msgstr "您分享的%(target)s中的问答主题“%(thread_subject)s”已关闭。"
+
+msgid "Q&A thread \"%(thread_subject)s\" was reopened on your shared %(target)s."
+msgstr "您分享的%(target)s中的问答主题“%(thread_subject)s”已重新开启。"
+
+msgid "Unknown uploader"
+msgstr "未知上传者"
+
+msgid "%(uploader)s uploaded \"%(file_name)s\" to file request \"%(req_name)s\"."
+msgstr "%(uploader)s 向文件收集“%(req_name)s”上传了“%(file_name)s”。"
+
+msgid "%(uploader)s uploaded \"%(file_name)s\"."
+msgstr "%(uploader)s 上传了“%(file_name)s”。"
+
+msgid "%(uploader)s uploaded to file request \"%(req_name)s\"."
+msgstr "%(uploader)s 向文件收集“%(req_name)s”上传了文件。"
+
+msgid "%(uploader)s uploaded a file."
+msgstr "%(uploader)s 上传了一个文件。"
+
+msgid "Malware was detected in uploaded file \"%(file_name)s\" to file request \"%(req_name)s\" from %(uploader)s."
+msgstr "在 %(uploader)s 向文件收集“%(req_name)s”上传的文件“%(file_name)s”中检测到恶意软件。"
+
+msgid "Malware was detected in uploaded file \"%(file_name)s\" from %(uploader)s."
+msgstr "在 %(uploader)s 上传的文件“%(file_name)s”中检测到恶意软件。"
+
+msgid "Malware was detected in uploaded file to file request \"%(req_name)s\" from %(uploader)s."
+msgstr "在 %(uploader)s 向文件收集“%(req_name)s”上传的文件中检测到恶意软件。"
+
+msgid "Malware was detected in uploaded file from %(uploader)s."
+msgstr "在 %(uploader)s 上传的文件中检测到恶意软件。"
+
+msgid "Malware scanning failed for uploaded file \"%(file_name)s\" to file request \"%(req_name)s\" from %(uploader)s."
+msgstr "%(uploader)s 向文件收集“%(req_name)s”上传的文件“%(file_name)s”恶意软件扫描失败。"
+
+msgid "Malware scanning failed for uploaded file \"%(file_name)s\" from %(uploader)s."
+msgstr "%(uploader)s 上传的文件“%(file_name)s”恶意软件扫描失败。"
+
+msgid "Malware scanning failed for uploaded file to file request \"%(req_name)s\" from %(uploader)s."
+msgstr "%(uploader)s 向文件收集“%(req_name)s”上传的文件恶意软件扫描失败。"
+
+msgid "Malware scanning failed for uploaded file from %(uploader)s."
+msgstr "%(uploader)s 上传的文件恶意软件扫描失败。"
+
+msgid "Coneshare automation event \"%(event_type)s\" was triggered for %(target)s."
+msgstr "已针对%(target)s触发 Coneshare 自动化事件“%(event_type)s”。"
+
+msgid "%(minutes)dm %(seconds)ds"
+msgstr "%(minutes)d分%(seconds)d秒"
+
+msgid "%(minutes)dm"
+msgstr "%(minutes)d分"
+
+msgid "%(seconds)ds"
+msgstr "%(seconds)d秒"
+
+
+

--- a/backend/tests/automations/test_tasks.py
+++ b/backend/tests/automations/test_tasks.py
@@ -663,3 +663,136 @@ def test_deliver_task_email_destination_debounced_reschedules_retry(mock_apply_a
     assert kwargs.get('countdown') >= 5
 
 
+@patch('automations.emails.send_mail')
+def test_deliver_task_email_coalesced_respects_user_language(mock_send_mail, user, share_link):
+    from sharelinks.models import ViewSession, PageView
+    from automations.models import AutomationDelivery
+    from documents.models import Document
+    from datetime import timedelta
+    from django.utils import timezone
+
+    user.language = 'zh-hans'
+    user.save(update_fields=['language'])
+
+    share_link.receive_email_notification = True
+    share_link.save()
+
+    doc = Document.objects.create(
+        organization=user.organization,
+        name="Financial_Statement.pdf",
+        num_pages=4,
+        created_by=user,
+    )
+    share_link.document = doc
+    share_link.save()
+
+    view_session = ViewSession.objects.create(
+        share_link=share_link,
+        viewer_email='viewer@example.com',
+    )
+    PageView.objects.create(
+        view_session=view_session,
+        page_number=1,
+        duration_seconds=30,
+        media_type='document',
+    )
+
+    delivery = _make_delivery(user, share_link)
+    delivery.destination.destination_type = 'email'
+    delivery.destination.save()
+    delivery.payload = {
+        'organization_id': str(user.organization.id),
+        'share_link_id': str(share_link.id),
+        'document_name': 'Financial_Statement.pdf',
+        'viewer_email': 'viewer@example.com',
+        'view_session_id': str(view_session.id),
+    }
+    delivery.save()
+    AutomationDelivery.objects.filter(id=delivery.id).update(created_at=timezone.now() - timedelta(seconds=70))
+
+    deliver_automation_delivery_task(str(delivery.id))
+
+    mock_send_mail.assert_called_once()
+    _, call_kwargs = mock_send_mail.call_args
+    # Subject should be translated into Chinese
+    assert "viewer@example.com 查看了文档“Financial_Statement.pdf”" in call_kwargs['subject']
+    # Message should be translated into Chinese
+    assert "访问详情" in call_kwargs['html_message']
+    assert "未知位置" in call_kwargs['message']
+    assert "30秒，已阅读 25%" in call_kwargs['message']
+
+
+def test_format_duration_localization():
+    from django.utils.translation import override as translation_override
+    from automations.emails import _format_duration
+
+    with translation_override('en'):
+        assert _format_duration(150) == "2m 30s"
+        assert _format_duration(120) == "2m"
+        assert _format_duration(45) == "45s"
+
+    with translation_override('zh-hans'):
+        assert _format_duration(150) == "2分30秒"
+        assert _format_duration(120) == "2分"
+        assert _format_duration(45) == "45秒"
+
+    with translation_override('ru'):
+        assert _format_duration(150) == "2 мин 30 с"
+        assert _format_duration(120) == "2 мин"
+        assert _format_duration(45) == "45 с"
+
+
+def test_event_sentence_and_target_description_localization():
+    from django.utils.translation import override as translation_override
+    from automations.tasks import _build_event_sentence, _target_description
+
+    payload = {
+        'document_name': 'Annual_Report.pdf',
+        'dataroom_name': 'Secret Room',
+        'dataroom_folder_name': 'Finance',
+        'viewer_email': 'buyer@example.com',
+    }
+
+    with translation_override('zh-hans'):
+        target = _target_description(payload)
+        assert target == '资料室“Secret Room”中文件夹“Finance”下的文档“Annual_Report.pdf”'
+        sentence = _build_event_sentence('document_viewed', payload)
+        assert sentence == '您分享的资料室“Secret Room”中文件夹“Finance”下的文档“Annual_Report.pdf”已被buyer@example.com查看。'
+
+    with translation_override('ru'):
+        target = _target_description(payload)
+        assert target == 'документ «Annual_Report.pdf» в папке «Finance» в датаруме «Secret Room»'
+        sentence = _build_event_sentence('document_viewed', payload)
+        assert sentence == 'Ваш общий документ «Annual_Report.pdf» в папке «Finance» в датаруме «Secret Room» был просмотрен пользователем buyer@example.com.'
+
+
+@patch('automations.emails.send_mail')
+def test_deliver_task_standard_fallback_email_respects_user_language(mock_send_mail, user, share_link):
+    from automations.models import AutomationDelivery
+
+    user.language = 'zh-hans'
+    user.save(update_fields=['language'])
+
+    delivery = _make_delivery(user, share_link)
+    delivery.destination.destination_type = 'email'
+    delivery.destination.save()
+    delivery.event_type = 'file_request_uploaded'
+    delivery.payload = {
+        'organization_id': str(user.organization.id),
+        'file_request_name': 'KYC Documents',
+        'uploaded_by_name': 'Alice',
+        'uploaded_by_email': 'alice@example.com',
+        'uploaded_file_name': 'passport.jpg',
+    }
+    delivery.save()
+
+    deliver_automation_delivery_task(str(delivery.id))
+
+    mock_send_mail.assert_called_once()
+    _, call_kwargs = mock_send_mail.call_args
+    assert 'Alice <alice@example.com> 向您的文件收集“KYC Documents”上传了文件' in call_kwargs['subject']
+    assert '访问详情' in call_kwargs['html_message']
+
+
+
+


### PR DESCRIPTION
- Wrap coalesced and fallback email rendering in translation_override(owner_lang)
- Localize notification headline and subject using gettext
- Add and compile translations in zh_Hans and ru message catalogs
- Add unit test asserting localized email dispatch in test_tasks.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email notifications now support localized subjects and content based on the recipient’s language.
  * Added Russian and Simplified Chinese translations for activity, sharing, document, file-request, malware, and reading-progress notifications.

* **Bug Fixes**
  * Fixed coalesced email notifications to consistently honor language preferences, including translated details and fallback text.

* **Tests**
  * Added coverage verifying localized email delivery for Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->