### PR TITLE
fix(viewer): reload dataroom documents reopened after navigating away

### DIFF
--- a/frontend/src/components/viewer/DataroomViewer.jsx
+++ b/frontend/src/components/viewer/DataroomViewer.jsx
@@ -469,6 +469,12 @@ export function DataroomViewer({ data, slug, viewId }) {
   }, [scopeData?.pagination?.next_offset, parentIdFromUrl, fetchScopeData]);
 
   // Document inline viewing logic
+  // activeDocIdRef must always be cleared with documentViewData, or the guard below blocks refetches.
+  const clearDocumentView = useCallback(() => {
+    activeDocIdRef.current = null;
+    setDocumentViewData(null);
+  }, []);
+
   const fetchDocumentViewData = useCallback(async (docId, { force = false } = {}) => {
     if (activeDocIdRef.current === docId && !force) {
       return;
@@ -489,6 +495,9 @@ export function DataroomViewer({ data, slug, viewId }) {
     } catch (err) {
       if (requestId !== docRequestRef.current) return;
       console.error('Failed to load document view data:', err);
+      if (activeDocIdRef.current === docId) {
+        activeDocIdRef.current = null;
+      }
       toast.error('Could not load document. Please try again.');
     } finally {
       if (requestId === docRequestRef.current) {
@@ -503,7 +512,7 @@ export function DataroomViewer({ data, slug, viewId }) {
         fetchDocumentViewData(selectedDocumentId);
       }
     } else {
-      setDocumentViewData(null);
+      clearDocumentView();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDocumentId, documentViewData?.id, fetchDocumentViewData]);
@@ -609,7 +618,7 @@ export function DataroomViewer({ data, slug, viewId }) {
       }
       setSearchParams(nextParams);
 
-      setDocumentViewData(null);
+      clearDocumentView();
     } else {
       if (documentViewData && String(documentViewData.id) === String(item.id) && documentViewData.name !== item.name) {
         setDocumentViewData(prev => prev ? { ...prev, name: item.name } : null);
@@ -623,8 +632,21 @@ export function DataroomViewer({ data, slug, viewId }) {
         nextParams.set('view_session_id', viewId);
       }
       setSearchParams(nextParams);
+
+      if (String(selectedDocumentId) === String(item.id) && !documentViewData && !isDocumentLoading) {
+        fetchDocumentViewData(item.id, { force: true });
+      }
     }
-  }, [viewId, searchParams, setSearchParams, documentViewData]);
+  }, [
+    viewId,
+    searchParams,
+    setSearchParams,
+    documentViewData,
+    clearDocumentView,
+    selectedDocumentId,
+    isDocumentLoading,
+    fetchDocumentViewData,
+  ]);
 
   const showDocumentViewer = Boolean(selectedDocumentId);
 
@@ -856,7 +878,7 @@ export function DataroomViewer({ data, slug, viewId }) {
                   nextParams.set('view_session_id', viewId);
                 }
                 setSearchParams(nextParams);
-                setDocumentViewData(null);
+                clearDocumentView();
               }}
               className="flex items-center gap-2"
               style={{ color: 'var(--viewer-secondary)' }}
@@ -877,7 +899,7 @@ export function DataroomViewer({ data, slug, viewId }) {
                     nextParams.set('view_session_id', viewId);
                   }
                   setSearchParams(nextParams);
-                  setDocumentViewData(null);
+                  clearDocumentView();
                 }}
                 className="ml-2"
                 style={{ color: 'var(--viewer-secondary)' }}

--- a/frontend/src/tests/components/viewer/DataroomViewer.test.jsx
+++ b/frontend/src/tests/components/viewer/DataroomViewer.test.jsx
@@ -817,4 +817,161 @@ describe('DataroomViewer', () => {
       }));
     });
   });
+
+  const subFolderDoc = {
+    type: 'document',
+    id: 'doc2',
+    document_id: 'doc-file-2',
+    name: 'Sub Folder Document',
+    document_type: 'pdf',
+    updated_at: new Date().toISOString(),
+    file_size: 2048,
+    allow_download: true,
+  };
+
+  const mockSubFolderNavigation = () => {
+    api.getShareLinkViewData.mockImplementation((slug, query) => {
+      if (query?.parentId === 'folder1') {
+        return Promise.resolve({
+          data: {
+            ...mockDataroomData,
+            current_parent_id: 'folder1',
+            breadcrumbs: [{ id: 'folder1', name: 'Sub Folder A' }],
+            items: [subFolderDoc],
+          },
+        });
+      }
+      if (query?.dataroomDocumentId === 'doc2') {
+        return Promise.resolve({
+          data: {
+            id: 'doc2',
+            name: 'Sub Folder Document',
+            type: 'document',
+            preview_mode: 'client_pdf',
+            num_pages: 14,
+            link_settings: { allow_download: true },
+          },
+        });
+      }
+      return Promise.resolve({ data: mockDataroomData });
+    });
+  };
+
+  const docFetchCount = (docId) =>
+    api.getShareLinkViewData.mock.calls.filter(([, query]) => query?.dataroomDocumentId === docId).length;
+
+  it('opens a document clicked from a subfolder list view', async () => {
+    mockSubFolderNavigation();
+
+    render(
+      <MemoryRouter initialEntries={['/view/test-slug']}>
+        <DataroomViewer data={mockDataroomData} slug="test-slug" viewId="view-123" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTitle('Sub Folder A'));
+    await screen.findByTitle('Sub Folder Document');
+
+    fireEvent.click(screen.getByTitle('Sub Folder Document'));
+
+    await waitFor(() => {
+      expect(api.getShareLinkViewData).toHaveBeenCalledWith('test-slug', expect.objectContaining({
+        dataroomDocumentId: 'doc2',
+      }));
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Loading document...')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('No document view data available.')).not.toBeInTheDocument();
+  });
+
+  it('refetches a document re-opened after navigating back to the folder list', async () => {
+    mockSubFolderNavigation();
+
+    render(
+      <MemoryRouter initialEntries={['/view/test-slug']}>
+        <DataroomViewer data={mockDataroomData} slug="test-slug" viewId="view-123" />
+      </MemoryRouter>
+    );
+
+    // Enter the subfolder and open the document once.
+    fireEvent.click(screen.getByTitle('Sub Folder A'));
+    await screen.findByTitle('Sub Folder Document');
+    fireEvent.click(screen.getByTitle('Sub Folder Document'));
+    await waitFor(() => {
+      expect(docFetchCount('doc2')).toBe(1);
+    });
+
+    // Navigate back out to the root list, then into the subfolder again.
+    fireEvent.click(screen.getByRole('button', { name: /^root$/i }));
+    await screen.findByTitle('Sub Folder A');
+    fireEvent.click(screen.getByTitle('Sub Folder A'));
+    await screen.findByTitle('Sub Folder Document');
+
+    // Re-open the same document.
+    fireEvent.click(screen.getByTitle('Sub Folder Document'));
+
+    await waitFor(() => {
+      expect(docFetchCount('doc2')).toBe(2);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Loading document...')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('No document view data available.')).not.toBeInTheDocument();
+  });
+
+  it('retries a document fetch when the same item is clicked after a failure', async () => {
+    let shouldFail = true;
+    api.getShareLinkViewData.mockImplementation((slug, query) => {
+      if (query?.parentId === 'folder1') {
+        return Promise.resolve({
+          data: {
+            ...mockDataroomData,
+            current_parent_id: 'folder1',
+            breadcrumbs: [{ id: 'folder1', name: 'Sub Folder A' }],
+            items: [subFolderDoc],
+          },
+        });
+      }
+      if (query?.dataroomDocumentId === 'doc2') {
+        if (shouldFail) {
+          shouldFail = false;
+          return Promise.reject(new Error('network down'));
+        }
+        return Promise.resolve({
+          data: {
+            id: 'doc2',
+            name: 'Sub Folder Document',
+            type: 'document',
+            preview_mode: 'client_pdf',
+            num_pages: 14,
+            link_settings: { allow_download: true },
+          },
+        });
+      }
+      return Promise.resolve({ data: mockDataroomData });
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/view/test-slug']}>
+        <DataroomViewer data={mockDataroomData} slug="test-slug" viewId="view-123" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTitle('Sub Folder A'));
+    await screen.findByTitle('Sub Folder Document');
+    fireEvent.click(screen.getByTitle('Sub Folder Document'));
+
+    await screen.findByText('No document view data available.');
+
+    // Click the same document again from the sidebar tree.
+    fireEvent.click(await screen.findByTitle('Sub Folder Document'));
+
+    await waitFor(() => {
+      expect(docFetchCount('doc2')).toBe(2);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('No document view data available.')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
Opening a dataroom document showed `No document view data available.` in an empty pane, and the app never sent the view-data request. It happens when you reopen a file you already viewed once in the same session, from the folder list or the sidebar tree.

`activeDocIdRef` in `DataroomViewer` dedupes view-data requests that are still in flight. The effect that reads it treats it as the id of the document currently loaded, and nothing ever clears it. So whenever `documentViewData` goes back to null, which happens on folder navigation, on deselect, and on a failed fetch, the ref keeps the old id and the guard blocks every later request for that document.

- Pair `activeDocIdRef` with `documentViewData` behind `clearDocumentView()` so both clear together
- Clear the ref when a view-data request fails, so a retry actually retries
- Add tests for opening a document from a subfolder list view and for reopening one after navigating back to the list

`npm run test:whitelist` passes 234 tests. The 7 `useSortedList` localStorage failures also fail on a clean checkout and are unrelated to this change.

Thanks for a great project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document loading when navigating between folders and subfolders.
  * Documents can now be reopened correctly after returning to the root folder.
  * Improved recovery after document-load failures, preventing stale document views and fallback messages.

* **Tests**
  * Added coverage for subfolder navigation, document reopening, and expected document fetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->