### PR TITLE
fix(backend): touch parent folder mtime when contents change (close #…

### DIFF
--- a/backend/datarooms/services.py
+++ b/backend/datarooms/services.py
@@ -1,6 +1,7 @@
 import logging
 from django.db import transaction
 from django.db.models import Q
+from django.utils import timezone
 
 from documents.models import Folder, Document
 from documents.services import delete_document_and_files
@@ -8,6 +9,25 @@ from .models import Dataroom, DataroomDocument, DataroomFolder
 from .utils import get_dataroom_storage_folder_name
 
 logger = logging.getLogger(__name__)
+
+
+def touch_dataroom_folder_ancestors(folder: DataroomFolder | None):
+    """
+    Updates the modification timestamp (updated_at) for the given DataroomFolder
+    and all its ancestor folders up to the root in a single batch UPDATE query.
+    """
+    if not folder:
+        return
+    now = timezone.now()
+    ancestor_ids = []
+    visited = set()
+    current = folder
+    while current and current.id not in visited:
+        visited.add(current.id)
+        ancestor_ids.append(current.id)
+        current = current.parent
+    if ancestor_ids:
+        DataroomFolder.objects.filter(id__in=ancestor_ids).update(updated_at=now)
 
 
 def delete_dataroom(dataroom: Dataroom):
@@ -88,7 +108,7 @@ def remove_dataroom_content(dataroom: Dataroom, dataroom_doc_ids: list = None, d
         DataroomDocument.objects.filter(
             Q(id__in=dataroom_doc_ids) | Q(folder_id__in=all_folder_ids),
             dataroom=dataroom
-        ).select_related('document', 'document__folder')
+        ).select_related('document', 'document__folder', 'folder')
     )
     ddoc_ids_to_remove = {d.id for d in ddocs_to_remove}
 
@@ -138,11 +158,27 @@ def remove_dataroom_content(dataroom: Dataroom, dataroom_doc_ids: list = None, d
                 backing_docs_to_delete.append(doc)
 
     # 4. Perform deletion
+    parent_folders_to_touch = set()
+    for ddoc in ddocs_to_remove:
+        if ddoc.folder and ddoc.folder.id not in all_folder_ids:
+            parent_folders_to_touch.add(ddoc.folder)
+
+    if dataroom_folder_ids:
+        folders_being_deleted = DataroomFolder.objects.filter(
+            id__in=dataroom_folder_ids,
+            dataroom=dataroom
+        ).select_related('parent')
+        for folder in folders_being_deleted:
+            if folder.parent and folder.parent.id not in all_folder_ids:
+                parent_folders_to_touch.add(folder.parent)
+
     with transaction.atomic():
         if dataroom_doc_ids:
             DataroomDocument.objects.filter(id__in=dataroom_doc_ids, dataroom=dataroom).delete()
         if dataroom_folder_ids:
             DataroomFolder.objects.filter(id__in=dataroom_folder_ids, dataroom=dataroom).delete()
+        for parent_folder in parent_folders_to_touch:
+            touch_dataroom_folder_ancestors(parent_folder)
 
     # Delete backing documents and storage files for direct uploads with no other references (non-blocking)
     for doc in backing_docs_to_delete:

--- a/backend/datarooms/views.py
+++ b/backend/datarooms/views.py
@@ -27,7 +27,11 @@ from documents.fileserver import fileserver_client
 from sharelinks.models import ViewSession
 from sharelinks.serializers import ViewSessionSerializer
 from .models import Dataroom, DataroomDocument, DataroomFolder, DataroomItemOrder
-from .services import delete_dataroom, remove_dataroom_content
+from .services import (
+    delete_dataroom,
+    remove_dataroom_content,
+    touch_dataroom_folder_ancestors,
+)
 from .utils import get_dataroom_storage_folder_name, build_ordered_dataroom_items
 from .serializers import (
     AddContentSerializer, DataroomDetailSerializer,
@@ -212,6 +216,9 @@ class DataroomViewSet(viewsets.ModelViewSet):
                 for folder in folders_to_add:
                     self._replicate_folder_structure(dataroom, folder, destination_folder, request.user)
 
+                if destination_folder:
+                    touch_dataroom_folder_ancestors(destination_folder)
+
             return Response({"detail": "Content added successfully."}, status=status.HTTP_200_OK)
         except PermissionDenied as e:
             return Response({"detail": str(e)}, status=status.HTTP_403_FORBIDDEN)
@@ -334,8 +341,11 @@ class DataroomViewSet(viewsets.ModelViewSet):
 
                 # TODO: This loop executes a save() for each document being moved, which can cause performance issues
                 # (N+1 queries) when moving many documents. This should be converted to use bulk_update.
+                source_folders = set()
                 docs_to_move = DataroomDocument.objects.filter(id__in=doc_ids, dataroom=dataroom)
                 for doc in docs_to_move:
+                    if doc.folder:
+                        source_folders.add(doc.folder)
                     doc.name = self._get_unique_dataroom_document_name(dataroom, destination_folder, doc.name)
                     doc.folder = destination_folder
                     doc.save()
@@ -344,9 +354,16 @@ class DataroomViewSet(viewsets.ModelViewSet):
                 for folder in folders_to_move:
                     if folder.id == dest_folder_id:
                         raise serializers.ValidationError("Cannot move a folder into itself.")
+                    if folder.parent:
+                        source_folders.add(folder.parent)
                     folder.name = self._get_unique_dataroom_folder_name(dataroom, destination_folder, folder.name)
                     folder.parent = destination_folder
                     folder.save()
+
+                for src_folder in source_folders:
+                    touch_dataroom_folder_ancestors(src_folder)
+                if destination_folder:
+                    touch_dataroom_folder_ancestors(destination_folder)
 
             return Response({"detail": "Content moved successfully."}, status=status.HTTP_200_OK)
         except serializers.ValidationError as e:
@@ -462,6 +479,7 @@ class DataroomViewSet(viewsets.ModelViewSet):
                 sorted_paths = sorted(list(all_required_paths), key=lambda p: p.count(os.sep))
                 path_to_folder_map = {'': parent_folder}
 
+                any_created = False
                 for path_str in sorted_paths:
                     path = Path(path_str)
                     parent_path_str = str(path.parent) if path.parent != Path('.') else ''
@@ -480,6 +498,8 @@ class DataroomViewSet(viewsets.ModelViewSet):
                         name=folder_name,
                     )
                     path_to_folder_map[path_str] = folder
+                    if created:
+                        any_created = True
 
                     if created and dataroom.show_file_index and self._scope_has_item_order_rows(dataroom, parent_dataroom_folder):
                         self._append_item_order(
@@ -488,6 +508,9 @@ class DataroomViewSet(viewsets.ModelViewSet):
                             item_type=DataroomItemOrder.ITEM_TYPE_FOLDER,
                             folder=folder,
                         )
+
+                if any_created and parent_folder:
+                    touch_dataroom_folder_ancestors(parent_folder)
 
             return Response(
                 {
@@ -643,6 +666,9 @@ class DataroomViewSet(viewsets.ModelViewSet):
                         item_type=DataroomItemOrder.ITEM_TYPE_DOCUMENT,
                         dataroom_document=dataroom_doc,
                     )
+
+                if destination_folder:
+                    touch_dataroom_folder_ancestors(destination_folder)
         except Exception as e:
             logger.error(f"Failed to finalize dataroom document upload: {e}")
             return Response(
@@ -674,6 +700,7 @@ class DataroomDocumentViewSet(mixins.RetrieveModelMixin,
         instance = self.get_object()
         new_name = serializer.validated_data.get('name')
         old_name = instance.name
+        old_folder = instance.folder
 
         if new_name and new_name != old_name:
             if DataroomDocument.objects.filter(
@@ -683,7 +710,11 @@ class DataroomDocumentViewSet(mixins.RetrieveModelMixin,
             ).exclude(pk=instance.pk).exists():
                 raise serializers.ValidationError({'name': _('A document with this name already exists in this location.')})
 
-        serializer.save()
+        saved_doc = serializer.save()
+        if saved_doc.folder:
+            touch_dataroom_folder_ancestors(saved_doc.folder)
+        if old_folder and old_folder != saved_doc.folder:
+            touch_dataroom_folder_ancestors(old_folder)
 
         # Rename backing Document under "Dataroom Uploads" if it exists and is a direct upload
         if new_name and new_name != old_name:
@@ -764,6 +795,8 @@ class DataroomFolderViewSet(viewsets.ModelViewSet):
             raise PermissionDenied("You do not have permission to add folders to this dataroom.")
 
         folder = serializer.save()
+        if folder.parent:
+            touch_dataroom_folder_ancestors(folder.parent)
         if dataroom.show_file_index and DataroomItemOrder.objects.filter(
             dataroom=dataroom, parent_folder=folder.parent
         ).exists():
@@ -785,6 +818,7 @@ class DataroomFolderViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         new_name = serializer.validated_data.get('name')
         old_name = instance.name
+        old_parent = instance.parent
 
         if new_name and new_name != old_name:
             if DataroomFolder.objects.filter(
@@ -794,7 +828,11 @@ class DataroomFolderViewSet(viewsets.ModelViewSet):
             ).exclude(pk=instance.pk).exists():
                 raise serializers.ValidationError({'name': _('A folder with this name already exists in this location.')})
 
-        serializer.save()
+        saved_folder = serializer.save()
+        if saved_folder.parent:
+            touch_dataroom_folder_ancestors(saved_folder.parent)
+        if old_parent and old_parent != saved_folder.parent:
+            touch_dataroom_folder_ancestors(old_parent)
 
         # Rename the backing Folder under "Dataroom Uploads" if it exists
         if new_name and new_name != old_name:

--- a/backend/documents/services.py
+++ b/backend/documents/services.py
@@ -46,6 +46,25 @@ class QuotaExceededError(Exception):
     pass
 
 
+def touch_folder_ancestors(folder: Folder | None):
+    """
+    Updates the modification timestamp (updated_at) for the given folder
+    and all its ancestor folders up to the root in a single batch UPDATE query.
+    """
+    if not folder:
+        return
+    now = timezone.now()
+    ancestor_ids = []
+    visited = set()
+    current = folder
+    while current and current.id not in visited:
+        visited.add(current.id)
+        ancestor_ids.append(current.id)
+        current = current.parent
+    if ancestor_ids:
+        Folder.objects.filter(id__in=ancestor_ids).update(updated_at=now)
+
+
 def check_user_quota_on_upload(user: User, new_file_size: int, document_to_update: Document = None):
     """
     Checks if a new upload would exceed the user's file size quota.
@@ -426,6 +445,7 @@ def create_document_from_upload(
         file_size=file_size,
         content_type=content_type,
     )
+    touch_folder_ancestors(document.folder)
 
     return document
 
@@ -470,6 +490,7 @@ def delete_folder_and_contents(folder: Folder):
     if deletion_errors:
         raise Exception(f"Failed to delete one or more associated files: {', '.join(deletion_errors)}")
 
+    parent_folder = folder.parent
     with transaction.atomic():
         user = folder.created_by
         if user and total_size > 0:
@@ -477,6 +498,8 @@ def delete_folder_and_contents(folder: Folder):
         # Explicitly delete the documents. This will cascade to versions and pages.
         documents_to_delete.delete()
         folder.delete()
+        if parent_folder:
+            touch_folder_ancestors(parent_folder)
 
 
 def delete_document_and_files(document: Document):
@@ -509,6 +532,7 @@ def delete_document_and_files(document: Document):
         # Re-raise an exception to be handled by the calling view.
         raise Exception(f"Failed to delete one or more associated files: {', '.join(deletion_errors)}")
 
+    parent_folder = document.folder
     # Atomically update user's total size and delete the document record
     with transaction.atomic():
         user = document.created_by
@@ -516,6 +540,8 @@ def delete_document_and_files(document: Document):
             User.objects.filter(pk=user.pk).update(total_document_size=F('total_document_size') - document.file_size)
         # Delete the document record, which will cascade to versions, pages, share links etc.
         document.delete()
+        if parent_folder:
+            touch_folder_ancestors(parent_folder)
 
 
 def copy_document(original_doc: Document, user: User) -> Document:
@@ -612,6 +638,7 @@ def copy_document(original_doc: Document, user: User) -> Document:
             file_size=new_doc.file_size,
             content_type=new_doc.content_type
         )
+        touch_folder_ancestors(new_doc.folder)
 
         return new_doc
     except Exception as e:
@@ -755,6 +782,7 @@ def process_imported_file(document: Document, file_data: dict, version_id=None):
             User.objects.filter(pk=user.pk).update(
                 total_document_size=F('total_document_size') - old_file_size + file_size
             )
+        touch_folder_ancestors(document.folder)
 
 
 def promote_document_version(document: Document, version: DocumentVersion, requesting_user: User):
@@ -838,6 +866,7 @@ def promote_document_version(document: Document, version: DocumentVersion, reque
     # passed to this function. Refresh from DB to ensure the caller (e.g. view serializer)
     # receives up-to-date metadata in memory.
     document.refresh_from_db()
+    touch_folder_ancestors(document.folder)
 
 
 def soft_delete_document(document: Document, user: User):
@@ -845,6 +874,7 @@ def soft_delete_document(document: Document, user: User):
     document.deleted_at = timezone.now()
     document.deleted_by = user
     document.save(update_fields=['deleted_at', 'deleted_by', 'updated_at'])
+    touch_folder_ancestors(document.folder)
 
 
 def soft_delete_folder(folder: Folder, user: User):
@@ -865,6 +895,7 @@ def soft_delete_folder(folder: Folder, user: User):
             deleted_at=now,
             deleted_by=user
         )
+        touch_folder_ancestors(folder.parent)
 
 
 def restore_item(item, item_type: str, user: User):
@@ -964,6 +995,8 @@ def restore_item(item, item_type: str, user: User):
                 deleted_by=None
             )
             item.refresh_from_db()
+            touch_folder_ancestors(item.parent)
+            touch_folder_ancestors(item)
         else:
             if Document.objects.active().filter(folder=item.folder, name=item.name).exists():
                 item.name = _get_unique_document_name(item.created_by, item.folder, item.name)
@@ -972,6 +1005,7 @@ def restore_item(item, item_type: str, user: User):
             item.deleted_by = None
             item.save(update_fields=['name', 'deleted_at', 'deleted_by', 'updated_at'])
             item.refresh_from_db()
+            touch_folder_ancestors(item.folder)
 
         was_renamed = (item.name != original_name)
         return item, original_name, was_renamed

--- a/backend/documents/views.py
+++ b/backend/documents/views.py
@@ -43,6 +43,7 @@ from .services import (
     preview_mode_for_version,
     preview_status_for_render_status,
     promote_document_version,
+    touch_folder_ancestors,
 )
 
 
@@ -347,6 +348,7 @@ class EnsureFolderPathsView(APIView):
                 # Keep track of created/verified folders to avoid redundant lookups
                 path_to_folder_map = {'': root_folder}
 
+                any_created = False
                 for path_str in sorted_paths:
                     path = Path(path_str)
                     parent_path_str = str(path.parent) if path.parent != Path('.') else ''
@@ -367,14 +369,19 @@ class EnsureFolderPathsView(APIView):
                         )
 
                     folder_name = path.name
-                    folder, _ = Folder.objects.active().get_or_create(
+                    folder, created = Folder.objects.active().get_or_create(
                         organization=organization,
                         parent=parent_folder,
                         name=folder_name,
                         created_by=requesting_user
                     )
+                    if created:
+                        any_created = True
 
                     path_to_folder_map[path_str] = folder
+
+                if any_created and root_folder:
+                    touch_folder_ancestors(root_folder)
 
             return Response(
                 {
@@ -809,11 +816,12 @@ class FolderViewSet(viewsets.ModelViewSet):
 
         if not parent:
             parent = self._get_root_folder()
-        serializer.save(
+        folder = serializer.save(
             created_by=self.request.user,
             organization=self.request.user.organization,
             parent=parent
         )
+        touch_folder_ancestors(folder.parent)
 
     def perform_update(self, serializer):
         parent = serializer.validated_data.get('parent')
@@ -821,7 +829,11 @@ class FolderViewSet(viewsets.ModelViewSet):
             raise serializers.ValidationError(
                 {'parent': "You can only move folders to destinations you own."}
             )
-        serializer.save()
+        old_parent = serializer.instance.parent
+        folder = serializer.save()
+        touch_folder_ancestors(folder.parent)
+        if old_parent and old_parent != folder.parent:
+            touch_folder_ancestors(old_parent)
 
     def destroy(self, request, *args, **kwargs):
         folder = self.get_object()
@@ -859,6 +871,13 @@ class DocumentViewSet(viewsets.ModelViewSet):
         ).prefetch_related(
             'versions', 'share_links', 'share_links__view_sessions'
         )
+
+    def perform_update(self, serializer):
+        old_folder = serializer.instance.folder
+        document = serializer.save()
+        touch_folder_ancestors(document.folder)
+        if old_folder and old_folder != document.folder:
+            touch_folder_ancestors(old_folder)
 
     def list(self, request, *args, **kwargs):
         """
@@ -1166,6 +1185,14 @@ class MoveItemsView(APIView):
                 # as it results in N database queries for updates. To improve efficiency,
                 # you can collect the modified objects and use bulk_update to perform all updates
                 # in a single query for documents and another for folders.
+                source_folders = set()
+                for doc in documents_to_move:
+                    if doc.folder:
+                        source_folders.add(doc.folder)
+                for folder in folders_to_move:
+                    if folder.parent:
+                        source_folders.add(folder.parent)
+
                 for doc in documents_to_move:
                     doc.name = _get_unique_document_name(
                         requesting_user=user,
@@ -1184,6 +1211,10 @@ class MoveItemsView(APIView):
                     )
                     folder.parent = destination_folder
                     folder.save()
+
+                for src_folder in source_folders:
+                    touch_folder_ancestors(src_folder)
+                touch_folder_ancestors(destination_folder)
 
             return Response({"detail": "Items moved successfully."}, status=status.HTTP_200_OK)
 

--- a/backend/tests/datarooms/test_views.py
+++ b/backend/tests/datarooms/test_views.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +9,7 @@ from rest_framework import status
 from rest_framework.exceptions import APIException
 
 from datarooms.models import Dataroom, DataroomDocument, DataroomFolder, DataroomItemOrder
+from datarooms.services import touch_dataroom_folder_ancestors
 from datarooms.utils import get_dataroom_storage_folder_name
 from documents.models import Document, Folder
 from sharelinks.models import DataroomVisit, ShareLink, ViewSession
@@ -1490,5 +1492,164 @@ class TestDataroomDocumentViewSet:
 
         assert not Dataroom.objects.filter(id=dr.id).exists()
         assert not Folder.objects.filter(id=dr_folder.id).exists()
+
+
+class TestDataroomFolderMtimeUpdates:
+    def test_touch_dataroom_folder_ancestors_updates_tree(self, dataroom):
+        """Test that touch_dataroom_folder_ancestors updates the timestamp of dataroom folder and ancestors."""
+        past_time = timezone.now() - timedelta(days=2)
+        root_folder = DataroomFolder.objects.create(name="DR Root", dataroom=dataroom)
+        sub1 = DataroomFolder.objects.create(name="DR Sub1", parent=root_folder, dataroom=dataroom)
+        sub2 = DataroomFolder.objects.create(name="DR Sub2", parent=sub1, dataroom=dataroom)
+
+        DataroomFolder.objects.filter(id__in=[root_folder.id, sub1.id, sub2.id]).update(updated_at=past_time)
+        root_folder.refresh_from_db()
+        sub1.refresh_from_db()
+        sub2.refresh_from_db()
+        assert root_folder.updated_at == past_time
+        assert sub1.updated_at == past_time
+        assert sub2.updated_at == past_time
+
+        touch_dataroom_folder_ancestors(sub2)
+
+        root_folder.refresh_from_db()
+        sub1.refresh_from_db()
+        sub2.refresh_from_db()
+        assert root_folder.updated_at > past_time
+        assert sub1.updated_at > past_time
+        assert sub2.updated_at > past_time
+
+    def test_create_dataroom_folder_touches_parent(self, api_client, dataroom):
+        """Test creating a subfolder in dataroom touches its parent DataroomFolder."""
+        api_client.force_authenticate(user=dataroom.created_by)
+        parent_folder = DataroomFolder.objects.create(name="Parent", dataroom=dataroom)
+        past_time = timezone.now() - timedelta(days=2)
+        DataroomFolder.objects.filter(id=parent_folder.id).update(updated_at=past_time)
+        parent_folder.refresh_from_db()
+        assert parent_folder.updated_at == past_time
+
+        res = api_client.post('/api/v1/dataroom-folders/', {
+            'name': 'New Child Folder',
+            'parent': parent_folder.id,
+            'dataroom': dataroom.id
+        }, format='json')
+        assert res.status_code == status.HTTP_201_CREATED
+
+        parent_folder.refresh_from_db()
+        assert parent_folder.updated_at > past_time
+
+    def test_move_dataroom_items_touches_source_and_dest_folders(self, api_client, dataroom, document):
+        """Test moving dataroom items touches both source and destination DataroomFolders."""
+        api_client.force_authenticate(user=dataroom.created_by)
+        source_folder = DataroomFolder.objects.create(name="Source DR", dataroom=dataroom)
+        dest_folder = DataroomFolder.objects.create(name="Dest DR", dataroom=dataroom)
+        ddoc = DataroomDocument.objects.create(name="file.pdf", dataroom=dataroom, folder=source_folder, document=document)
+
+        past_time = timezone.now() - timedelta(days=2)
+        DataroomFolder.objects.filter(id__in=[source_folder.id, dest_folder.id]).update(updated_at=past_time)
+        source_folder.refresh_from_db()
+        dest_folder.refresh_from_db()
+        assert source_folder.updated_at == past_time
+        assert dest_folder.updated_at == past_time
+
+        res = api_client.post(f'/api/v1/datarooms/{dataroom.id}/move-content/', {
+            'dataroom_document_ids': [ddoc.id],
+            'dataroom_folder_ids': [],
+            'destination_folder_id': dest_folder.id
+        }, format='json')
+        assert res.status_code == status.HTTP_200_OK
+
+        source_folder.refresh_from_db()
+        dest_folder.refresh_from_db()
+        assert source_folder.updated_at > past_time
+        assert dest_folder.updated_at > past_time
+
+    def test_remove_nested_folder_with_documents_succeeds(self, api_client, dataroom, document):
+        """
+        Regression test: Deleting a parent folder that contains subfolders with documents
+        must not crash with DataroomFolder.DoesNotExist when attempting to touch deleted subfolder parents.
+        """
+        api_client.force_authenticate(user=dataroom.created_by)
+        parent_folder = DataroomFolder.objects.create(name="Parent Folder", dataroom=dataroom)
+        child_folder = DataroomFolder.objects.create(name="Child Folder", parent=parent_folder, dataroom=dataroom)
+        DataroomDocument.objects.create(name="child_doc.pdf", dataroom=dataroom, folder=child_folder, document=document)
+
+        res = api_client.post(f'/api/v1/datarooms/{dataroom.id}/remove-content/', {
+            'dataroom_document_ids': [],
+            'dataroom_folder_ids': [parent_folder.id]
+        }, format='json')
+        assert res.status_code == status.HTTP_204_NO_CONTENT
+        assert not DataroomFolder.objects.filter(id__in=[parent_folder.id, child_folder.id]).exists()
+
+    def test_touch_dataroom_folder_ancestors_with_cycle_safely_terminates(self, dataroom):
+        """Test that touch_dataroom_folder_ancestors does not infinite-loop if there is a cycle."""
+        f1 = DataroomFolder.objects.create(name="F1", dataroom=dataroom)
+        f2 = DataroomFolder.objects.create(name="F2", parent=f1, dataroom=dataroom)
+        # Mock a cycle in memory
+        f1.parent = f2
+        touch_dataroom_folder_ancestors(f2)  # Should terminate cleanly without hanging
+
+    def test_upload_finalize_touches_destination_folder_mtime(self, api_client, dataroom):
+        """Test that finalizing direct dataroom upload touches destination DataroomFolder updated_at."""
+        api_client.force_authenticate(user=dataroom.created_by)
+        dest_folder = DataroomFolder.objects.create(name="Upload Target", dataroom=dataroom)
+        past_time = timezone.now() - timedelta(days=2)
+        DataroomFolder.objects.filter(id=dest_folder.id).update(updated_at=past_time)
+        dest_folder.refresh_from_db()
+        assert dest_folder.updated_at == past_time
+
+        url_finalize = f'/api/v1/datarooms/{dataroom.id}/uploads/finalize/'
+        res = api_client.post(url_finalize, {
+            'storage_key': 'org_1/uploads/test_file.pdf',
+            'unique_name': 'test_file.pdf',
+            'file_size': 100,
+            'content_type': 'application/pdf',
+            'destination_folder_id': dest_folder.id,
+        }, format='json')
+        assert res.status_code == status.HTTP_202_ACCEPTED
+
+        dest_folder.refresh_from_db()
+        assert dest_folder.updated_at > past_time
+
+    def test_ensure_paths_touches_parent_folder_mtime(self, api_client, dataroom):
+        """Test that ensure_paths creates child folders and touches parent_folder updated_at."""
+        api_client.force_authenticate(user=dataroom.created_by)
+        parent_folder = DataroomFolder.objects.create(name="Base Folder", dataroom=dataroom)
+        past_time = timezone.now() - timedelta(days=2)
+        DataroomFolder.objects.filter(id=parent_folder.id).update(updated_at=past_time)
+        parent_folder.refresh_from_db()
+        assert parent_folder.updated_at == past_time
+
+        res = api_client.post(f'/api/v1/datarooms/{dataroom.id}/ensure-paths/', {
+            'paths': ['SubDir/NestedDir'],
+            'parent_folder_id': parent_folder.id,
+        }, format='json')
+        assert res.status_code == status.HTTP_201_CREATED
+
+        parent_folder.refresh_from_db()
+        assert parent_folder.updated_at > past_time
+
+    def test_add_content_touches_destination_folder_mtime(self, api_client, dataroom, document):
+        """Test that adding library content to a dataroom folder touches destination DataroomFolder updated_at."""
+        api_client.force_authenticate(user=dataroom.created_by)
+        dest_folder = DataroomFolder.objects.create(name="Add Content Target", dataroom=dataroom)
+        past_time = timezone.now() - timedelta(days=2)
+        DataroomFolder.objects.filter(id=dest_folder.id).update(updated_at=past_time)
+        dest_folder.refresh_from_db()
+        assert dest_folder.updated_at == past_time
+
+        add_to_folder_url = f'/api/v1/datarooms/{dataroom.id}/add-content/'
+        res = api_client.post(add_to_folder_url, {
+            'document_ids': [str(document.id)],
+            'destination_folder_id': str(dest_folder.id)
+        }, format='json')
+        assert res.status_code == status.HTTP_200_OK
+
+        dest_folder.refresh_from_db()
+        assert dest_folder.updated_at > past_time
+
+
+
+
 
 

--- a/backend/tests/documents/test_services.py
+++ b/backend/tests/documents/test_services.py
@@ -3,7 +3,10 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.test import override_settings
 
-from documents.models import Document, DocumentVersion, DocumentPage
+from datetime import timedelta
+from django.utils import timezone
+
+from documents.models import Document, DocumentVersion, DocumentPage, Folder
 from documents.services import (
     create_document_from_upload,
     delete_document_and_files,
@@ -15,6 +18,10 @@ from documents.services import (
     promote_document_version,
     check_user_quota_on_upload,
     get_effective_render_status,
+    touch_folder_ancestors,
+    soft_delete_document,
+    soft_delete_folder,
+    restore_item,
 )
 from core.services import get_dynamic_setting
 
@@ -617,5 +624,143 @@ class TestPromoteDocumentVersion:
         with patch('core.services.get_dynamic_setting', return_value=45):
             with pytest.raises(QuotaExceededError, match="Uploading this file would exceed your storage quota of 45 MB"):
                 check_user_quota_on_upload(user, 10)
+
+
+@pytest.mark.django_db
+class TestFolderMtimeUpdates:
+    def test_touch_folder_ancestors_updates_tree(self, user):
+        """Test that touch_folder_ancestors updates the timestamp of the folder and all its ancestors."""
+        past_time = timezone.now() - timedelta(days=2)
+        root = Folder.objects.create(name="Root", organization=user.organization, created_by=user)
+        sub1 = Folder.objects.create(name="Sub1", parent=root, organization=user.organization, created_by=user)
+        sub2 = Folder.objects.create(name="Sub2", parent=sub1, organization=user.organization, created_by=user)
+
+        Folder.objects.filter(id__in=[root.id, sub1.id, sub2.id]).update(updated_at=past_time)
+        root.refresh_from_db()
+        sub1.refresh_from_db()
+        sub2.refresh_from_db()
+        assert root.updated_at == past_time
+        assert sub1.updated_at == past_time
+        assert sub2.updated_at == past_time
+
+        touch_folder_ancestors(sub2)
+
+        root.refresh_from_db()
+        sub1.refresh_from_db()
+        sub2.refresh_from_db()
+        assert root.updated_at > past_time
+        assert sub1.updated_at > past_time
+        assert sub2.updated_at > past_time
+
+    def test_create_document_touches_parent_folder(self, user):
+        """Test that uploading/creating a document touches parent folder updated_at."""
+        past_time = timezone.now() - timedelta(days=1)
+        folder = Folder.objects.create(name="Folder", organization=user.organization, created_by=user)
+        Folder.objects.filter(id=folder.id).update(updated_at=past_time)
+        folder.refresh_from_db()
+        assert folder.updated_at == past_time
+
+        create_document_from_upload(
+            requesting_user=user,
+            folder=folder,
+            storage_key=f"{user.organization.id}/test.pdf",
+            unique_name="test.pdf",
+            file_size=100,
+            content_type="application/pdf"
+        )
+
+        folder.refresh_from_db()
+        assert folder.updated_at > past_time
+
+    def test_soft_delete_and_restore_document_touches_parent_folder(self, user):
+        """Test that soft deleting and restoring a document touches parent folder updated_at."""
+        past_time = timezone.now() - timedelta(days=1)
+        folder = Folder.objects.create(name="Folder", organization=user.organization, created_by=user)
+        doc = Document.objects.create(
+            name="file.pdf",
+            organization=user.organization,
+            folder=folder,
+            created_by=user,
+            type="pdf",
+            content_type="application/pdf"
+        )
+        Folder.objects.filter(id=folder.id).update(updated_at=past_time)
+        folder.refresh_from_db()
+        assert folder.updated_at == past_time
+
+        # 1. Soft delete touches parent folder
+        soft_delete_document(doc, user)
+        folder.refresh_from_db()
+        assert folder.updated_at > past_time
+
+        # 2. Reset and restore touches parent folder
+        Folder.objects.filter(id=folder.id).update(updated_at=past_time)
+        folder.refresh_from_db()
+        assert folder.updated_at == past_time
+
+        restore_item(doc, 'document', user)
+        folder.refresh_from_db()
+        assert folder.updated_at > past_time
+
+    def test_soft_delete_folder_touches_parent_folder(self, user):
+        """Test that soft deleting a subfolder touches its parent folder updated_at."""
+        past_time = timezone.now() - timedelta(days=1)
+        parent = Folder.objects.create(name="Parent", organization=user.organization, created_by=user)
+        child = Folder.objects.create(name="Child", parent=parent, organization=user.organization, created_by=user)
+        Folder.objects.filter(id=parent.id).update(updated_at=past_time)
+        parent.refresh_from_db()
+        assert parent.updated_at == past_time
+
+        soft_delete_folder(child, user)
+        parent.refresh_from_db()
+        assert parent.updated_at > past_time
+
+    def test_promote_document_version_touches_parent_folder(self, user):
+        """Test that promoting a document version touches parent folder updated_at."""
+        past_time = timezone.now() - timedelta(days=1)
+        folder = Folder.objects.create(name="Folder", organization=user.organization, created_by=user)
+        doc = Document.objects.create(
+            name="file.pdf",
+            organization=user.organization,
+            folder=folder,
+            created_by=user,
+            type="pdf",
+            content_type="application/pdf",
+            file_size=100
+        )
+        v1 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=1,
+            is_primary=True,
+            file_size=100,
+            content_type="application/pdf",
+            storage_key="v1.pdf",
+            type="pdf"
+        )
+        v2 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=2,
+            is_primary=False,
+            file_size=200,
+            content_type="application/pdf",
+            storage_key="v2.pdf",
+            type="pdf"
+        )
+        Folder.objects.filter(id=folder.id).update(updated_at=past_time)
+        folder.refresh_from_db()
+        assert folder.updated_at == past_time
+
+        promote_document_version(doc, v2, user)
+        folder.refresh_from_db()
+        assert folder.updated_at > past_time
+
+    def test_touch_folder_ancestors_with_cycle_safely_terminates(self, user):
+        """Test that touch_folder_ancestors does not infinite-loop if there is a cycle."""
+        f1 = Folder.objects.create(name="F1", organization=user.organization, created_by=user)
+        f2 = Folder.objects.create(name="F2", parent=f1, organization=user.organization, created_by=user)
+        # Mock a cycle in memory
+        f1.parent = f2
+        touch_folder_ancestors(f2)  # Should terminate cleanly without hanging
+
 
 

--- a/backend/tests/documents/test_views.py
+++ b/backend/tests/documents/test_views.py
@@ -1,4 +1,6 @@
 import pytest
+from datetime import timedelta
+from django.utils import timezone
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
@@ -2321,3 +2323,111 @@ def test_rename_document_with_duplicate_name_fails(api_client, user, organizatio
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert 'name' in response.json()
     assert 'already exists' in str(response.json()['name'])
+
+
+@pytest.mark.django_db
+def test_create_subfolder_touches_parent_folder_mtime(api_client, user, organization):
+    """Test creating a subfolder touches its parent folder updated_at."""
+    api_client.force_authenticate(user=user)
+    root_folder = Folder.objects.get_root_for_org(organization)
+    parent_folder = Folder.objects.create(name="Parent", organization=organization, created_by=user, parent=root_folder)
+    past_time = timezone.now() - timedelta(days=2)
+    Folder.objects.filter(id=parent_folder.id).update(updated_at=past_time)
+    parent_folder.refresh_from_db()
+    assert parent_folder.updated_at == past_time
+
+    res = api_client.post('/api/v1/folders/', {'name': 'New Child', 'parent': parent_folder.id}, format='json')
+    assert res.status_code == status.HTTP_201_CREATED
+
+    parent_folder.refresh_from_db()
+    assert parent_folder.updated_at > past_time
+
+
+@pytest.mark.django_db
+def test_rename_subfolder_touches_parent_folder_mtime(api_client, user, organization):
+    """Test renaming a subfolder touches its parent folder updated_at."""
+    api_client.force_authenticate(user=user)
+    root_folder = Folder.objects.get_root_for_org(organization)
+    parent_folder = Folder.objects.create(name="Parent", organization=organization, created_by=user, parent=root_folder)
+    child_folder = Folder.objects.create(name="Old Child", organization=organization, created_by=user, parent=parent_folder)
+    past_time = timezone.now() - timedelta(days=2)
+    Folder.objects.filter(id=parent_folder.id).update(updated_at=past_time)
+    parent_folder.refresh_from_db()
+    assert parent_folder.updated_at == past_time
+
+    res = api_client.patch(f'/api/v1/folders/{child_folder.id}/', {'name': 'Renamed Child'}, format='json')
+    assert res.status_code == status.HTTP_200_OK
+
+    parent_folder.refresh_from_db()
+    assert parent_folder.updated_at > past_time
+
+
+@pytest.mark.django_db
+def test_rename_document_touches_parent_folder_mtime(api_client, user, organization):
+    """Test renaming a document touches its parent folder updated_at."""
+    api_client.force_authenticate(user=user)
+    root_folder = Folder.objects.get_root_for_org(organization)
+    parent_folder = Folder.objects.create(name="Parent", organization=organization, created_by=user, parent=root_folder)
+    doc = Document.objects.create(name="doc.pdf", organization=organization, created_by=user, folder=parent_folder, status="ready")
+    past_time = timezone.now() - timedelta(days=2)
+    Folder.objects.filter(id=parent_folder.id).update(updated_at=past_time)
+    parent_folder.refresh_from_db()
+    assert parent_folder.updated_at == past_time
+
+    res = api_client.patch(f'/api/v1/documents/{doc.id}/', {'name': 'renamed_doc.pdf'}, format='json')
+    assert res.status_code == status.HTTP_200_OK
+
+    parent_folder.refresh_from_db()
+    assert parent_folder.updated_at > past_time
+
+
+@pytest.mark.django_db
+def test_bulk_move_items_touches_source_and_destination_folders(api_client, user, organization):
+    """Test moving documents/folders touches both source and destination parent folder updated_at."""
+    api_client.force_authenticate(user=user)
+    root_folder = Folder.objects.get_root_for_org(organization)
+    source_folder = Folder.objects.create(name="Source", organization=organization, created_by=user, parent=root_folder)
+    dest_folder = Folder.objects.create(name="Dest", organization=organization, created_by=user, parent=root_folder)
+    doc = Document.objects.create(name="move_me.pdf", organization=organization, created_by=user, folder=source_folder, status="ready")
+
+    past_time = timezone.now() - timedelta(days=2)
+    Folder.objects.filter(id__in=[source_folder.id, dest_folder.id]).update(updated_at=past_time)
+    source_folder.refresh_from_db()
+    dest_folder.refresh_from_db()
+    assert source_folder.updated_at == past_time
+    assert dest_folder.updated_at == past_time
+
+    res = api_client.post('/api/v1/actions/move/', {
+        'document_ids': [doc.id],
+        'folder_ids': [],
+        'destination_folder_id': dest_folder.id
+    }, format='json')
+    assert res.status_code == status.HTTP_200_OK
+
+    source_folder.refresh_from_db()
+    dest_folder.refresh_from_db()
+    assert source_folder.updated_at > past_time
+    assert dest_folder.updated_at > past_time
+
+
+@pytest.mark.django_db
+def test_ensure_folder_paths_touches_parent_folder_mtime(api_client, user, organization):
+    """Test that EnsureFolderPathsView touches parent folder updated_at when folders are created."""
+    api_client.force_authenticate(user=user)
+    root_folder = Folder.objects.get_root_for_org(organization)
+    parent_folder = Folder.objects.create(name="Doc Base", organization=organization, created_by=user, parent=root_folder)
+    past_time = timezone.now() - timedelta(days=2)
+    Folder.objects.filter(id=parent_folder.id).update(updated_at=past_time)
+    parent_folder.refresh_from_db()
+    assert parent_folder.updated_at == past_time
+
+    res = api_client.post('/api/v1/folders/ensure-paths/', {
+        'paths': ['SubFolder/DeepNested'],
+        'parent_path': parent_folder.name,
+    }, format='json')
+    assert res.status_code == status.HTTP_201_CREATED
+
+    parent_folder.refresh_from_db()
+    assert parent_folder.updated_at > past_time
+
+


### PR DESCRIPTION
…315)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folder activity timestamps now refresh consistently when content is created, updated, moved, deleted, restored, copied, imported, or promoted to a new version.
  * Changes to nested content now update timestamps for affected parent and ancestor folders.
  * Source and destination folder timestamps are both refreshed when items are moved.

* **Tests**
  * Added coverage for timestamp updates across dataroom and document folder operations, including nested deletions and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->