### PR TITLE
fix(datarooms): decouple direct uploads from user personal storage quota

### DIFF
--- a/.agent/memory.md
+++ b/.agent/memory.md
@@ -325,5 +325,7 @@ COMPOSE_PROJECT_NAME=coneshare docker-compose exec frontend npm test -- --run sr
 - **Category:** Architecture Choice / Debugging Break
 - **Context/Implication:** `GET /api/v1/analytics/dashboard/` incurred ~1s response times and 550+ SQL queries due to recursive serializer over-fetching (`ShareLinkSerializer` invoking full `ViewSessionSerializer` with nested pageviews and dataroom visits) and unindexed correlated subqueries.
 - **Resolution/Action:** Created dedicated lightweight serializers in `backend/analytics/serializers.py` (`DashboardRecentViewSessionSerializer` and `DashboardRecentLinkSerializer`), added batch prefetching and annotations in `DashboardSummaryView`, and added composite index `models.Index(fields=['share_link', '-viewed_at'])` to `ViewSession.Meta`.
-
-
+### 2026-09-04 Session Entry
+- **Category:** Architecture Choice
+- **Context/Implication:** Direct uploads into a Dataroom (`__datarooms__/<id>` vault storage) previously incremented the uploader's `user.total_document_size`, causing personal quota lockouts when uploading large files to high-capacity datarooms.
+- **Resolution/Action:** Decoupled direct Dataroom uploads from personal quota. Direct Dataroom uploads are governed solely by `dataroom.storage_quota_mb`. `create_document_from_upload(..., track_user_quota=False)` bypasses personal quota tracking, and `delete_document_and_files()` as well as `recalculate_user_document_size()` exclude vault-stored files via `is_dataroom_vault_document()`.

--- a/backend/datarooms/services.py
+++ b/backend/datarooms/services.py
@@ -5,8 +5,13 @@ from django.db import transaction
 from django.db.models import Q, Sum
 from django.utils import timezone
 
+from core.models import User
 from documents.models import Folder, Document
-from documents.services import delete_document_and_files, _get_unique_document_name, _get_unique_folder_name
+from documents.services import (
+    delete_document_and_files, _get_unique_document_name, _get_unique_folder_name,
+    recalculate_user_document_size
+)
+
 from .models import Dataroom, DataroomDocument, DataroomFolder
 from .utils import get_dataroom_storage_folder_name
 
@@ -243,7 +248,15 @@ def upgrade_dataroom_to_v2(dataroom: Dataroom) -> bool:
         ))
 
         # 3. Move direct contents into the system vault
+        affected_users = set()
+        if locked_dataroom.created_by:
+            affected_users.add(locked_dataroom.created_by)
+
         for old_folder in legacy_folders:
+            all_folder_ids = [old_folder.id] + [f.id for f in old_folder.get_descendants()]
+            for creator in User.objects.filter(documents_created__folder_id__in=all_folder_ids).distinct():
+                affected_users.add(creator)
+
             # Move child documents individually, ensuring unique names in vault_room_folder
             child_docs = list(Document.objects.filter(folder=old_folder).select_related('created_by'))
             for doc in child_docs:
@@ -267,6 +280,10 @@ def upgrade_dataroom_to_v2(dataroom: Dataroom) -> bool:
         locked_dataroom.storage_version = 2
         locked_dataroom.save(update_fields=['storage_version', 'updated_at'])
         dataroom.storage_version = 2
+
+        # 5. Automatically free personal quota for uploaders whose legacy documents moved to the vault
+        for u in affected_users:
+            recalculate_user_document_size(u)
 
     return True
 
@@ -346,9 +363,10 @@ def remove_dataroom_content(dataroom: Dataroom, dataroom_doc_ids: list = None, d
             touch_dataroom_folder_ancestors(parent_folder)
 
     # Delete backing documents and storage files for direct uploads with no other references (non-blocking)
+    is_vault = (dataroom.storage_version >= 2)
     for doc in backing_docs_to_delete:
         try:
-            delete_document_and_files(doc)
+            delete_document_and_files(doc, is_vault=is_vault)
         except Exception as e:
             logger.exception("Failed to clean up backing document %s: %s", doc.id, e)
 

--- a/backend/datarooms/views.py
+++ b/backend/datarooms/views.py
@@ -574,14 +574,6 @@ class DataroomViewSet(viewsets.ModelViewSet):
 
         validated_data = serializer.validated_data
 
-        try:
-            check_user_quota_on_upload(
-                user=request.user,
-                new_file_size=validated_data['file_size']
-            )
-        except QuotaExceededError as e:
-            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
         # Check Dataroom storage quota cap (0 means unlimited)
         if dataroom.storage_quota_mb and dataroom.storage_quota_mb > 0:
             current_room_usage = get_dataroom_storage_used_bytes(dataroom)
@@ -591,6 +583,14 @@ class DataroomViewSet(viewsets.ModelViewSet):
                     {'detail': f"Uploading this file would exceed the Dataroom storage limit of {dataroom.storage_quota_mb} MB."},
                     status=status.HTTP_400_BAD_REQUEST
                 )
+
+        # For legacy v1 datarooms whose backing storage resides in personal storage ('Dataroom Uploads'),
+        # enforce user personal storage quota. Modern v2 system vaults bypass user quota.
+        if dataroom.storage_version < 2:
+            try:
+                check_user_quota_on_upload(request.user, validated_data['file_size'])
+            except QuotaExceededError as e:
+                return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         file_name = validated_data['file_name']
         relative_path = validated_data.get('path')
@@ -699,6 +699,9 @@ class DataroomViewSet(viewsets.ModelViewSet):
                             status=status.HTTP_400_BAD_REQUEST
                         )
 
+                # Modern v2 system vaults (__datarooms__) do not track user personal quota.
+                # Legacy v1 uploads reside in personal storage ('Dataroom Uploads') and track user quota.
+                track_user_quota = (locked_dataroom.storage_version < 2)
                 document = create_document_from_upload(
                     requesting_user=request.user,
                     folder=library_folder,
@@ -706,6 +709,7 @@ class DataroomViewSet(viewsets.ModelViewSet):
                     unique_name=validated_data['unique_name'],
                     file_size=validated_data['file_size'],
                     content_type=validated_data['content_type'],
+                    track_user_quota=track_user_quota,
                 )
 
                 unique_name = self._get_unique_dataroom_document_name(

--- a/backend/documents/services.py
+++ b/backend/documents/services.py
@@ -3,6 +3,7 @@ import mimetypes
 import logging
 import requests
 import uuid
+from typing import Optional
 from django.utils import timezone
 
 from django.conf import settings
@@ -90,18 +91,45 @@ def check_user_quota_on_upload(user: User, new_file_size: int, document_to_updat
         )
 
 
+def is_dataroom_vault_document(document: Document) -> bool:
+    """
+    Returns True if the document belongs to the organization Dataroom storage vault.
+
+    Folder Invariant:
+    1. Personal folders: Created by end users, strictly having `created_by = <User>`.
+    2. Org root folder: `__root__` has `created_by = None`, but `parent_id = None`.
+    3. System vault folders: `__datarooms__` and all descendant folders are created with
+       `created_by = None` and `parent_id IS NOT NULL`.
+
+    Therefore, `folder.created_by_id is None and folder.parent_id is not None` guarantees
+    the document resides inside the organization system vault in O(1) without requiring
+    recursive CTEs or parent hierarchy tree traversal.
+    """
+    if not document or not document.folder_id:
+        return False
+
+    folder = document.folder
+    return bool(folder and folder.created_by_id is None and folder.parent_id is not None)
+
+
 def recalculate_user_document_size(user: User) -> int:
     """
     Computes and updates the true total_document_size for a user from their active documents.
+    Excludes documents residing in the organization Dataroom storage vault.
     Returns the corrected size in bytes.
+
+    Uses the folder invariant (`folder__created_by__isnull=True, folder__parent__isnull=False`)
+    to exclude all system vault documents in a single atomic SQL query without needing to
+    traverse the folder tree.
     """
     with transaction.atomic():
         locked_user = User.objects.select_for_update().get(pk=user.pk)
-        actual_size = (
-            Document.objects.active()
-            .filter(created_by=locked_user)
-            .aggregate(total=Sum('file_size'))['total'] or 0
+        qs = Document.objects.active().filter(created_by=locked_user).exclude(
+            folder__created_by__isnull=True,
+            folder__parent__isnull=False
         )
+
+        actual_size = qs.aggregate(total=Sum('file_size'))['total'] or 0
         locked_user.total_document_size = max(0, actual_size)
         locked_user.save(update_fields=['total_document_size'])
         user.total_document_size = locked_user.total_document_size
@@ -383,6 +411,7 @@ def create_document_from_upload(
     unique_name: str,
     file_size: int,
     content_type: str,
+    track_user_quota: bool = True,
 ) -> Document:
     """
     Creates document records from data about a file already uploaded to the
@@ -421,7 +450,8 @@ def create_document_from_upload(
                     content_type=content_type,
                     original_storage_key=storage_key,
                 )
-                User.objects.filter(pk=requesting_user.pk).update(total_document_size=F('total_document_size') + file_size)
+                if track_user_quota:
+                    User.objects.filter(pk=requesting_user.pk).update(total_document_size=F('total_document_size') + file_size)
             break
         except IntegrityError:
             if attempt == max_retries - 1:
@@ -502,9 +532,11 @@ def delete_folder_and_contents(folder: Folder):
             touch_folder_ancestors(parent_folder)
 
 
-def delete_document_and_files(document: Document):
+def delete_document_and_files(document: Document, is_vault: Optional[bool] = None):
     """
     Deletes a document, its versions, pages, and all associated files from storage.
+    If is_vault is provided, uses it directly to determine whether to skip decrementing
+    personal storage quota, avoiding hierarchy traversal queries on bulk deletions.
     """
     storage_keys_to_delete = set()
 
@@ -536,7 +568,8 @@ def delete_document_and_files(document: Document):
     # Atomically update user's total size and delete the document record
     with transaction.atomic():
         user = document.created_by
-        if user and document.file_size:
+        is_vault_doc = is_vault if is_vault is not None else is_dataroom_vault_document(document)
+        if user and document.file_size and not is_vault_doc:
             User.objects.filter(pk=user.pk).update(total_document_size=F('total_document_size') - document.file_size)
         # Delete the document record, which will cascade to versions, pages, share links etc.
         document.delete()

--- a/backend/tests/core/test_admin_views.py
+++ b/backend/tests/core/test_admin_views.py
@@ -345,6 +345,56 @@ class TestAdminOrganizationView:
         assert member.total_document_size == 1024 + 2048
         assert response.data['total_document_size'] == 3072
 
+    def test_recalculate_user_quota_excludes_dataroom_vault_documents(self, admin_api_client, admin_user):
+        from documents.models import Document, Folder
+        from datarooms.models import Dataroom
+        from datarooms.services import get_or_create_dataroom_storage_folder
+
+        member = User.objects.create_user(
+            username='member_vault_quota@example.com',
+            email='member_vault_quota@example.com',
+            organization=admin_user.organization,
+            role='member',
+            total_document_size=50 * 1024 * 1024 + 1024,  # Bloated with historical vault upload
+        )
+
+        # 1. Personal document (1024 bytes)
+        Document.objects.create(
+            organization=admin_user.organization,
+            created_by=member,
+            name='personal_notes.pdf',
+            file_size=1024,
+            status='ready'
+        )
+
+        # 2. Modern Dataroom vault document (50 MB)
+        dataroom = Dataroom.objects.create(
+            name="Confidential Deal",
+            organization=admin_user.organization,
+            created_by=member,
+            storage_quota_mb=500,
+            storage_version=2
+        )
+        vault_folder = get_or_create_dataroom_storage_folder(dataroom, member)
+        Document.objects.create(
+            organization=admin_user.organization,
+            folder=vault_folder,
+            created_by=member,
+            name='deal_deck.pdf',
+            file_size=50 * 1024 * 1024,
+            status='ready'
+        )
+
+        # Admin triggers quota recalculation from user panel
+        url = f'/api/v1/admin/users/{member.id}/recalculate-quota/'
+        response = admin_api_client.post(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        member.refresh_from_db()
+        # Only personal document (1024 bytes) must be counted
+        assert member.total_document_size == 1024
+        assert response.data['total_document_size'] == 1024
+
     def test_recalculate_user_quota_non_admin_forbidden(self, api_client, user):
         url = f'/api/v1/admin/users/{user.id}/recalculate-quota/'
         response = api_client.post(url)

--- a/backend/tests/datarooms/test_views.py
+++ b/backend/tests/datarooms/test_views.py
@@ -9,9 +9,10 @@ from rest_framework import status
 from rest_framework.exceptions import APIException
 
 from datarooms.models import Dataroom, DataroomDocument, DataroomFolder, DataroomItemOrder
-from datarooms.services import touch_dataroom_folder_ancestors
+from datarooms.services import touch_dataroom_folder_ancestors, get_dataroom_storage_used_bytes
 from datarooms.utils import get_dataroom_storage_folder_name
 from documents.models import Document, Folder
+from documents.services import recalculate_user_document_size
 from sharelinks.models import DataroomVisit, ShareLink, ViewSession
 
 pytestmark = pytest.mark.django_db
@@ -200,7 +201,7 @@ class TestDataroomViewSet:
         assert res.status_code == status.HTTP_202_ACCEPTED
 
         user.refresh_from_db()
-        assert user.total_document_size == file_size
+        assert user.total_document_size == 0
 
         # Delete dataroom
         res_delete = api_client.delete(f'/api/v1/datarooms/{dataroom.id}/')
@@ -209,8 +210,142 @@ class TestDataroomViewSet:
         user.refresh_from_db()
         assert user.total_document_size == 0, f"Expected total_document_size to be 0, got {user.total_document_size}"
 
+    @patch('documents.services.fileserver_client.generate_upload_url', return_value='http://fileserver/upload')
+    @patch('documents.services.fileserver_client.delete_file')
+    def test_direct_upload_does_not_consume_user_personal_quota(self, mock_fs_delete, mock_fs_upload, api_client, user, organization):
+        """
+        Option A verification:
+        A user has a 10 MB personal quota.
+        The dataroom has a 500 MB capacity.
+        Uploading a 50 MB file directly to the dataroom must NOT be blocked by the user's personal quota,
+        must NOT increment the user's personal total_document_size, and must NOT block subsequent uploads
+        to the user's personal workspace.
+        """
+        user.custom_file_size_quota_mb = 10
+        user.total_document_size = 0
+        user.save()
+
+        dataroom = Dataroom.objects.create(
+            name="Deal Dataroom",
+            organization=organization,
+            created_by=user,
+            storage_quota_mb=500,
+            storage_version=2
+        )
+
+        file_size = 50 * 1024 * 1024  # 50 MB (exceeds user's 10 MB personal quota)
+        url_request = f'/api/v1/datarooms/{dataroom.id}/uploads/request/'
+        data_request = {
+            'file_name': 'big_deal_deck.pdf',
+            'file_size': file_size,
+        }
+        res_req = api_client.post(url_request, data_request, format='json')
+        assert res_req.status_code == status.HTTP_200_OK, f"Expected 200, got {res_req.status_code}: {res_req.data}"
+
+        url_finalize = f'/api/v1/datarooms/{dataroom.id}/uploads/finalize/'
+        data_finalize = {
+            'storage_key': 'org_1/uploads/big_deal_deck.pdf',
+            'unique_name': res_req.data.get('unique_name', 'big_deal_deck.pdf'),
+            'file_size': file_size,
+            'content_type': 'application/pdf',
+        }
+        res_fin = api_client.post(url_finalize, data_finalize, format='json')
+        assert res_fin.status_code == status.HTTP_202_ACCEPTED
+
+        # 1. User's personal total_document_size must remain 0
+        user.refresh_from_db()
+        assert user.total_document_size == 0, f"Expected user personal quota usage to be 0, got {user.total_document_size}"
+
+        # 2. Recalculating user quota must also yield 0
+        assert recalculate_user_document_size(user) == 0
+
+        # 3. Dataroom's storage usage must record the 50 MB
+        assert get_dataroom_storage_used_bytes(dataroom) == file_size
+
+        # 4. User should still be able to upload to their personal workspace (5 MB <= 10 MB)
+        res_personal = api_client.post('/api/v1/uploads/document/request/', {
+            'file_name': 'personal_notes.pdf',
+            'file_size': 5 * 1024 * 1024,
+        }, format='json')
+        assert res_personal.status_code == status.HTTP_200_OK
+
+    @patch('documents.services.fileserver_client.generate_upload_url', return_value='http://fileserver/upload')
+    @patch('documents.services.fileserver_client.delete_file')
+    def test_legacy_v1_direct_upload_consumes_user_personal_quota(self, mock_fs_delete, mock_fs_upload, api_client, user, organization):
+        """
+        Legacy v1 verification:
+        Legacy v1 datarooms store direct uploads under personal storage ('Dataroom Uploads').
+        1. Direct upload request checks personal quota and blocks if exceeded.
+        2. Successful v1 upload increments user.total_document_size.
+        3. Recalculate includes legacy personal files.
+        4. Upgrading the dataroom to v2 moves files to '__datarooms__' vault and frees personal quota upon recalculation.
+        """
+        user.custom_file_size_quota_mb = 10
+        user.total_document_size = 0
+        user.save()
+
+        dataroom = Dataroom.objects.create(
+            name="Legacy Room",
+            organization=organization,
+            created_by=user,
+            storage_quota_mb=500,
+            storage_version=1
+        )
+
+        # 1. Attempt upload that exceeds personal quota (15 MB > 10 MB) -> must fail with 400
+        url_request = f'/api/v1/datarooms/{dataroom.id}/uploads/request/'
+        res_fail = api_client.post(url_request, {'file_name': 'too_big.pdf', 'file_size': 15 * 1024 * 1024}, format='json')
+        assert res_fail.status_code == status.HTTP_400_BAD_REQUEST
+        assert "exceed your storage quota" in res_fail.data['detail']
+
+        # 2. Upload a file at root and a file in a subfolder within personal quota
+        file_size = 2 * 1024 * 1024
+        res_ok = api_client.post(url_request, {'file_name': 'doc.pdf', 'file_size': file_size}, format='json')
+        assert res_ok.status_code == status.HTTP_200_OK
+
+        url_finalize = f'/api/v1/datarooms/{dataroom.id}/uploads/finalize/'
+        res_fin = api_client.post(url_finalize, {
+            'storage_key': 'org_1/uploads/doc.pdf',
+            'unique_name': res_ok.data.get('unique_name', 'doc.pdf'),
+            'file_size': file_size,
+            'content_type': 'application/pdf',
+        }, format='json')
+        assert res_fin.status_code == status.HTTP_202_ACCEPTED
+
+        # Upload a second file inside a subfolder
+        finance_folder = DataroomFolder.objects.create(dataroom=dataroom, name='Finance', created_by=user)
+        subfolder_file_size = 1 * 1024 * 1024
+        res_sub_req = api_client.post(url_request, {'file_name': 'sub_doc.pdf', 'file_size': subfolder_file_size, 'destination_folder_id': finance_folder.id}, format='json')
+        assert res_sub_req.status_code == status.HTTP_200_OK
+
+        res_sub_fin = api_client.post(url_finalize, {
+            'storage_key': 'org_1/uploads/sub_doc.pdf',
+            'unique_name': res_sub_req.data.get('unique_name', 'sub_doc.pdf'),
+            'file_size': subfolder_file_size,
+            'content_type': 'application/pdf',
+            'destination_folder_id': finance_folder.id
+        }, format='json')
+        assert res_sub_fin.status_code == status.HTTP_202_ACCEPTED
+
+        total_uploaded = file_size + subfolder_file_size
+        user.refresh_from_db()
+        assert user.total_document_size == total_uploaded
+        assert recalculate_user_document_size(user) == total_uploaded
+
+        # 3. Upgrade dataroom to v2 (moves backing documents including subfolders to __datarooms__ vault)
+        res_upgrade = api_client.post(f'/api/v1/datarooms/{dataroom.id}/upgrade-storage/')
+        assert res_upgrade.status_code == status.HTTP_200_OK
+        dataroom.refresh_from_db()
+        assert dataroom.storage_version == 2
+
+        # 4. Upgrading automatically recalculated and freed the uploader's personal quota
+        user.refresh_from_db()
+        assert user.total_document_size == 0
+        assert recalculate_user_document_size(user) == 0
+
     @patch('documents.services.fileserver_client.delete_file')
     def test_delete_dataroom_with_shared_direct_upload_preserves_shared_document(self, mock_fs_delete, api_client, dataroom, user, organization):
+
         """
         Test that deleting a dataroom preserves backing documents that are also linked
         in another dataroom.
@@ -1032,13 +1167,16 @@ class TestDataroomViewSet:
             assert response_non_existent.status_code == status.HTTP_400_BAD_REQUEST
             assert "Folder path 'NonExistent' does not exist in this dataroom." in response_non_existent.json()['detail']
 
-            # 4. Test quota exceeded
-            with patch('datarooms.views.check_user_quota_on_upload') as mock_check_quota:
-                from documents.services import QuotaExceededError
-                mock_check_quota.side_effect = QuotaExceededError("Quota exceeded.")
-                response_quota = api_client.post(url, data, format='json')
-                assert response_quota.status_code == status.HTTP_400_BAD_REQUEST
-                assert "Quota exceeded." in response_quota.json()['detail']
+            # 4. Test dataroom storage quota exceeded
+            dataroom.storage_quota_mb = 1
+            dataroom.save()
+            data_oversized = {
+                'file_name': 'oversized.pdf',
+                'file_size': 2 * 1024 * 1024,
+            }
+            response_quota = api_client.post(url, data_oversized, format='json')
+            assert response_quota.status_code == status.HTTP_400_BAD_REQUEST
+            assert "exceed the Dataroom storage limit" in response_quota.json()['detail']
 
     @patch('documents.fileserver.fileserver_client.generate_upload_url')
     def test_upload_request_inside_folder_with_path(self, mock_generate_url, api_client, dataroom):

--- a/backend/tests/documents/test_views.py
+++ b/backend/tests/documents/test_views.py
@@ -1037,6 +1037,7 @@ def test_get_document_preview_data_too_many_pages(api_client, user):
 
 
 @pytest.mark.django_db
+@override_settings(PDF_PREVIEW_ENGINE='server_pages')
 @patch('documents.views.fileserver_client.delete_file')
 @patch('documents.services.generate_pdf_pages_task.delay')
 def test_post_rebuild_preview(mock_task_delay, mock_delete_file, api_client, user):
@@ -1128,6 +1129,7 @@ def test_rebuild_preview_concurrency_conflict(mock_task_delay, mock_delete_file,
 
 
 @pytest.mark.django_db
+@override_settings(PDF_PREVIEW_ENGINE='server_pages')
 @patch('documents.views.fileserver_client.delete_file')
 @patch('documents.services.generate_pdf_pages_task.delay')
 def test_rebuild_preview_no_existing_pages(mock_task_delay, mock_delete_file, api_client, user):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Direct uploads to modern Dataroom vaults no longer consume personal document storage quota.
  * Dataroom uploads are now governed by the Dataroom’s storage limit.
  * Personal quota tracking remains enforced for legacy Datarooms.
  * Deleting or recalculating storage usage now correctly excludes vault-stored documents.
  * Upgrading a legacy Dataroom to the modern storage system now releases affected files from personal quota calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->