### PR TITLE
fix(datarooms): clear created_by on subfolders during v2 upgrade to r…

### DIFF
--- a/.agent/memory.md
+++ b/.agent/memory.md
@@ -335,4 +335,10 @@ COMPOSE_PROJECT_NAME=coneshare docker-compose exec frontend npm test -- --run sr
 - **Context/Implication:** Removing or renaming documents and folders in a Dataroom broke the View Sessions activity log (rendering empty "Viewed document: " strings or retroactively mutating historical names).
 - **Resolution/Action:** Added point-in-time snapshot fields (`item_type`, `item_name`, `item_path`, `document_type`) to `DataroomVisit` populated at access/download time, with `get_full_path()` hierarchy tracking on `DataroomFolder`. `DataroomVisitSerializer` falls back to snapshots when foreign keys are null and outputs `item_status` (`active`, `deleted`, `renamed`). The frontend renders subtle `[Deleted]` and `[Renamed]` status badges and path tooltips. Data backfill migration `0010` backfills existing live rows and omits `elidable=True` so squashed migrations preserve the backfill for unmigrated environments.
 
+### 2026-09-05 Session Entry
+- **Category:** Gotcha
+- **Context/Implication:** In `upgrade_dataroom_to_v2()`, reparenting legacy backing subfolders into the system vault (`__datarooms__/<id>/`) did not clear `created_by` on the subfolders or their descendants. Because the vault invariant relies on `folder.created_by_id is None and folder.parent_id is not None` to identify vault documents in $O(1)$, documents inside subfolders were not excluded by `recalculate_user_document_size()`, leaving the uploader's personal quota inflated.
+- **Resolution/Action:** In `upgrade_dataroom_to_v2()`, pass `created_by=None` to `_get_unique_folder_name()`, set `subf.created_by = None`, and batch-update all descendant folders with `Folder.objects.filter(id__in=descendant_ids).update(created_by=None)`.
+
+
 

--- a/backend/datarooms/services.py
+++ b/backend/datarooms/services.py
@@ -253,7 +253,8 @@ def upgrade_dataroom_to_v2(dataroom: Dataroom) -> bool:
             affected_users.add(locked_dataroom.created_by)
 
         for old_folder in legacy_folders:
-            all_folder_ids = [old_folder.id] + [f.id for f in old_folder.get_descendants()]
+            all_descendants = old_folder.get_descendants()
+            all_folder_ids = [old_folder.id] + [f.id for f in all_descendants]
             for creator in User.objects.filter(documents_created__folder_id__in=all_folder_ids).distinct():
                 affected_users.add(creator)
 
@@ -268,10 +269,17 @@ def upgrade_dataroom_to_v2(dataroom: Dataroom) -> bool:
             # Move child subfolders individually, ensuring unique names in vault_room_folder
             child_folders = list(Folder.objects.filter(parent=old_folder).select_related('created_by'))
             for subf in child_folders:
-                unique_folder_name = _get_unique_folder_name(subf.created_by, vault_room_folder, subf.name)
+                unique_folder_name = _get_unique_folder_name(None, vault_room_folder, subf.name)
                 subf.name = unique_folder_name
                 subf.parent = vault_room_folder
-                subf.save(update_fields=['name', 'parent'])
+                subf.created_by = None
+                subf.save(update_fields=['name', 'parent', 'created_by'])
+
+            # Ensure all deeper descendant folders also adhere to vault invariant (created_by=None)
+            # Reuses all_descendants collected above to eliminate redundant N+1 tree traversals
+            deeper_descendant_ids = [f.id for f in all_descendants if f.parent_id != old_folder.id]
+            if deeper_descendant_ids:
+                Folder.objects.filter(id__in=deeper_descendant_ids).update(created_by=None)
 
             # Delete the empty legacy folder shell
             old_folder.delete()

--- a/backend/tests/datarooms/test_views.py
+++ b/backend/tests/datarooms/test_views.py
@@ -12,7 +12,7 @@ from datarooms.models import Dataroom, DataroomDocument, DataroomFolder, Dataroo
 from datarooms.services import touch_dataroom_folder_ancestors, get_dataroom_storage_used_bytes
 from datarooms.utils import get_dataroom_storage_folder_name
 from documents.models import Document, Folder
-from documents.services import recalculate_user_document_size
+from documents.services import recalculate_user_document_size, is_dataroom_vault_document
 from sharelinks.models import DataroomVisit, ShareLink, ViewSession
 
 pytestmark = pytest.mark.django_db
@@ -2135,6 +2135,71 @@ class TestDataroomFolderMtimeUpdates:
 
         # Both subfolders should now be in the new vault folder with distinct names
         assert subf1.parent_id == subf2.parent_id
+
+    def test_v1_dataroom_upgrade_clears_created_by_on_subfolders_and_deducts_user_quota(self, api_client, user, organization):
+        """Test that upgrading a v1 dataroom clears created_by on subfolders and descendants to obey the vault invariant and deducts user quota."""
+        api_client.force_authenticate(user=user)
+        dataroom = Dataroom.objects.create(name="Project Beta", organization=organization, created_by=user, storage_version=1)
+
+        root_folder = Folder.objects.get_root_for_org(organization)
+        legacy_uploads = Folder.objects.create(organization=organization, parent=root_folder, name="Dataroom Uploads", created_by=user)
+        legacy_name = get_dataroom_storage_folder_name(dataroom.name, dataroom)
+        old_folder = Folder.objects.create(organization=organization, parent=legacy_uploads, name=legacy_name, created_by=user)
+
+        # Create child subfolder and nested subfolder in the legacy backing directory
+        subf = Folder.objects.create(organization=organization, parent=old_folder, name="Reports", created_by=user)
+        nested_subf = Folder.objects.create(organization=organization, parent=subf, name="2026", created_by=user)
+
+        # Direct doc under dataroom root
+        doc_root = Document.objects.create(
+            organization=organization, folder=old_folder, name="Root.pdf",
+            type="document", content_type="application/pdf", file_size=1000,
+            status="ready", created_by=user
+        )
+        # Doc in subfolder
+        doc_sub = Document.objects.create(
+            organization=organization, folder=subf, name="Sub.pdf",
+            type="document", content_type="application/pdf", file_size=2000,
+            status="ready", created_by=user
+        )
+        # Doc in nested subfolder
+        doc_nested = Document.objects.create(
+            organization=organization, folder=nested_subf, name="Nested.pdf",
+            type="document", content_type="application/pdf", file_size=2000,
+            status="ready", created_by=user
+        )
+        # Personal document outside dataroom
+        personal_folder = Folder.objects.create(organization=organization, parent=root_folder, name="My Private Docs", created_by=user)
+        personal_doc = Document.objects.create(
+            organization=organization, folder=personal_folder, name="Personal.pdf",
+            type="document", content_type="application/pdf", file_size=500,
+            status="ready", created_by=user
+        )
+
+        user.total_document_size = 5500
+        user.save(update_fields=['total_document_size'])
+
+        # Perform upgrade
+        res = api_client.post(f'/api/v1/datarooms/{dataroom.id}/upgrade-storage/')
+        assert res.status_code == status.HTTP_200_OK
+
+        dataroom.refresh_from_db()
+        assert dataroom.storage_version == 2
+
+        subf.refresh_from_db()
+        nested_subf.refresh_from_db()
+        assert subf.created_by is None
+        assert nested_subf.created_by is None
+
+        doc_root.refresh_from_db()
+        doc_sub.refresh_from_db()
+        doc_nested.refresh_from_db()
+        assert is_dataroom_vault_document(doc_root) is True
+        assert is_dataroom_vault_document(doc_sub) is True
+        assert is_dataroom_vault_document(doc_nested) is True
+
+        user.refresh_from_db()
+        assert user.total_document_size == 500
 
     def test_dataroom_stats(self, api_client, user, organization):
         """


### PR DESCRIPTION
…estore vault invariant and deduct quota

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dataroom upgrades so migrated folders and their contents are correctly recognized as system-owned vault items.
  * Corrected personal storage quota calculations after upgrading legacy datarooms, preventing migrated documents from inflating user quotas.

* **Tests**
  * Added coverage verifying ownership handling, vault recognition, and quota adjustments during dataroom upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->