### PR TITLE
fix(documents): bypass user personal quota and enforce dataroom quota…

### DIFF
--- a/.agent/memory.md
+++ b/.agent/memory.md
@@ -340,5 +340,11 @@ COMPOSE_PROJECT_NAME=coneshare docker-compose exec frontend npm test -- --run sr
 - **Context/Implication:** In `upgrade_dataroom_to_v2()`, reparenting legacy backing subfolders into the system vault (`__datarooms__/<id>/`) did not clear `created_by` on the subfolders or their descendants. Because the vault invariant relies on `folder.created_by_id is None and folder.parent_id is not None` to identify vault documents in $O(1)$, documents inside subfolders were not excluded by `recalculate_user_document_size()`, leaving the uploader's personal quota inflated.
 - **Resolution/Action:** In `upgrade_dataroom_to_v2()`, pass `created_by=None` to `_get_unique_folder_name()`, set `subf.created_by = None`, and batch-update all descendant folders with `Folder.objects.filter(id__in=descendant_ids).update(created_by=None)`.
 
+### 2026-09-06 Session Entry
+- **Category:** Architecture Choice
+- **Context/Implication:** Document version promotion (`promote_document_version`) was unconditionally checking the requesting user's personal quota and updating `user.total_document_size`, causing version promotions on org vault / v2 Dataroom files to fail or pollute personal quota counters.
+- **Resolution/Action:** Guarded `promote_document_version` with `is_dataroom_vault_document(locked_doc)`. When true, bypass personal quota checks and `user.total_document_size` updates, and instead enforce `droom.storage_quota_mb` checks against the associated Dataroom(s).
+
+
 
 

--- a/backend/documents/services.py
+++ b/backend/documents/services.py
@@ -838,12 +838,41 @@ def promote_document_version(document: Document, version: DocumentVersion, reque
         locked_doc = Document.objects.select_for_update().get(pk=document.pk)
         old_file_size = locked_doc.file_size or 0
 
-        if requesting_user and new_file_size > old_file_size:
+        is_vault_doc = is_dataroom_vault_document(locked_doc)
+
+        if not is_vault_doc and requesting_user and new_file_size > old_file_size:
             check_user_quota_on_upload(
                 user=requesting_user,
                 new_file_size=new_file_size,
                 document_to_update=locked_doc
             )
+        elif is_vault_doc and new_file_size > old_file_size:
+            from datarooms.models import Dataroom, DataroomDocument
+            from datarooms.services import get_dataroom_storage_used_bytes
+
+            delta = new_file_size - old_file_size
+            dataroom_ids = list(
+                DataroomDocument.objects.filter(document=locked_doc)
+                .values_list('dataroom_id', flat=True)
+                .distinct()
+            )
+            if dataroom_ids:
+                # Lock affected datarooms in stable ID order to serialize quota checks and prevent deadlocks
+                locked_datarooms = list(
+                    Dataroom.objects.select_for_update()
+                    .filter(id__in=dataroom_ids)
+                    .order_by('id')
+                )
+                for droom in locked_datarooms:
+                    if droom.storage_quota_mb and droom.storage_quota_mb > 0:
+                        room_quota_bytes = droom.storage_quota_mb * 1024 * 1024
+                        current_usage = get_dataroom_storage_used_bytes(droom)
+                        if current_usage + delta > room_quota_bytes:
+                            raise QuotaExceededError(
+                                f"Promoting this version would exceed the Dataroom storage limit of {droom.storage_quota_mb} MB."
+                            )
+
+
 
         # Deactivate all current primary versions
         document.versions.filter(is_primary=True).update(is_primary=False)
@@ -888,8 +917,8 @@ def promote_document_version(document: Document, version: DocumentVersion, reque
 
         locked_doc.save()
 
-        # Update user's total document size
-        if requesting_user and old_file_size != new_file_size:
+        # Update user's total document size for personal documents (vault documents are tracked under datarooms)
+        if not is_vault_doc and requesting_user and old_file_size != new_file_size:
             User.objects.filter(pk=requesting_user.pk).update(
                 total_document_size=F('total_document_size') - old_file_size + new_file_size
             )

--- a/backend/tests/documents/test_services.py
+++ b/backend/tests/documents/test_services.py
@@ -22,6 +22,7 @@ from documents.services import (
     soft_delete_document,
     soft_delete_folder,
     restore_item,
+    is_dataroom_vault_document,
 )
 from core.services import get_dynamic_setting
 
@@ -595,6 +596,334 @@ class TestPromoteDocumentVersion:
 
         with pytest.raises(ValidationError, match="already the active version"):
             promote_document_version(doc, v1, user)
+
+    def test_promote_version_in_vault_does_not_consume_user_quota(self, user):
+        """Promoting a version of a vault document should not increase user's total_document_size."""
+        root_folder = Folder.objects.create(
+            name="__root__",
+            organization=user.organization,
+            created_by=None,
+            parent=None,
+        )
+        vault_folder = Folder.objects.create(
+            name="__datarooms__",
+            organization=user.organization,
+            created_by=None,
+            parent=root_folder,
+        )
+        room_folder = Folder.objects.create(
+            name="Room_1",
+            organization=user.organization,
+            created_by=None,
+            parent=vault_folder,
+        )
+
+        doc = Document.objects.create(
+            organization=user.organization,
+            created_by=user,
+            folder=room_folder,
+            name="vault_doc.pdf",
+            type="pdf",
+            content_type="application/pdf",
+            file_size=100,
+            status="ready",
+        )
+        assert is_dataroom_vault_document(doc) is True
+
+        v1 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=1,
+            is_primary=True,
+            file_size=100,
+            content_type="application/pdf",
+            original_storage_key="vault_v1.pdf",
+            storage_key="vault_v1.pdf",
+            type="pdf",
+            render_status=DocumentVersion.RENDER_READY,
+        )
+        v2 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=2,
+            is_primary=False,
+            file_size=500,
+            content_type="application/pdf",
+            original_storage_key="vault_v2.pdf",
+            storage_key="vault_v2.pdf",
+            type="pdf",
+            render_status=DocumentVersion.RENDER_READY,
+        )
+
+        user.total_document_size = 0
+        user.save()
+
+        # Act
+        promote_document_version(doc, v2, user)
+
+        # Assert document updated
+        doc.refresh_from_db()
+        assert doc.file_size == 500
+        v2.refresh_from_db()
+        assert v2.is_primary is True
+
+        # Assert user's personal quota was NOT affected
+        user.refresh_from_db()
+        assert user.total_document_size == 0
+
+    @patch('core.services.get_dynamic_setting')
+    def test_promote_version_in_vault_succeeds_when_user_quota_exhausted(self, mock_get_setting, user):
+        """Promoting a version of a vault document should not be blocked if the user's personal quota is full."""
+        def get_setting_mock(key):
+            if key == 'FILE_SIZE_QUOTA_MB':
+                return 1  # 1 MB quota
+            elif key == 'MAX_PREVIEW_FILE_SIZE_MB':
+                return 100
+            elif key == 'MAX_VIDEO_PREVIEW_SIZE_MB':
+                return 100
+            return 0
+        mock_get_setting.side_effect = get_setting_mock
+
+        root_folder = Folder.objects.create(
+            name="__root__",
+            organization=user.organization,
+            created_by=None,
+            parent=None,
+        )
+        vault_folder = Folder.objects.create(
+            name="__datarooms__",
+            organization=user.organization,
+            created_by=None,
+            parent=root_folder,
+        )
+        room_folder = Folder.objects.create(
+            name="Room_1",
+            organization=user.organization,
+            created_by=None,
+            parent=vault_folder,
+        )
+
+        doc = Document.objects.create(
+            organization=user.organization,
+            created_by=user,
+            folder=room_folder,
+            name="vault_doc.pdf",
+            type="pdf",
+            content_type="application/pdf",
+            file_size=500 * 1024,
+            status="ready",
+        )
+        v1 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=1,
+            is_primary=True,
+            file_size=500 * 1024,
+            content_type="application/pdf",
+            original_storage_key="vault_v1.pdf",
+            storage_key="vault_v1.pdf",
+            type="pdf",
+            render_status=DocumentVersion.RENDER_READY,
+        )
+        v2 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=2,
+            is_primary=False,
+            file_size=2 * 1024 * 1024,  # 2 MB (> 1 MB user quota limit)
+            content_type="application/pdf",
+            original_storage_key="vault_v2.pdf",
+            storage_key="vault_v2.pdf",
+            type="pdf",
+            render_status=DocumentVersion.RENDER_READY,
+        )
+
+        # User's personal storage quota is completely exhausted
+        user.total_document_size = 1024 * 1024
+        user.save()
+
+        # Act: promoting the version on a vault document should succeed
+        promote_document_version(doc, v2, user)
+
+        doc.refresh_from_db()
+        assert doc.file_size == 2 * 1024 * 1024
+        user.refresh_from_db()
+        assert user.total_document_size == 1024 * 1024
+
+    def test_promote_version_in_vault_respects_dataroom_quota(self, user):
+        """Promoting a version of a vault document should enforce dataroom storage quota."""
+        from datarooms.models import Dataroom, DataroomDocument
+
+        dataroom = Dataroom.objects.create(
+            name="Confidential Project",
+            organization=user.organization,
+            created_by=user,
+            storage_quota_mb=1,  # 1 MB quota limit
+            storage_version=2,
+        )
+
+        root_folder = Folder.objects.create(
+            name="__root__",
+            organization=user.organization,
+            created_by=None,
+            parent=None,
+        )
+        vault_folder = Folder.objects.create(
+            name="__datarooms__",
+            organization=user.organization,
+            created_by=None,
+            parent=root_folder,
+        )
+        room_folder = Folder.objects.create(
+            name="Room_1",
+            organization=user.organization,
+            created_by=None,
+            parent=vault_folder,
+        )
+
+        doc = Document.objects.create(
+            organization=user.organization,
+            created_by=user,
+            folder=room_folder,
+            name="vault_doc.pdf",
+            type="pdf",
+            content_type="application/pdf",
+            file_size=500 * 1024,
+            status="ready",
+        )
+        DataroomDocument.objects.create(
+            dataroom=dataroom,
+            document=doc,
+            name="vault_doc.pdf",
+            is_direct_upload=True,
+        )
+
+        v1 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=1,
+            is_primary=True,
+            file_size=500 * 1024,
+            content_type="application/pdf",
+            original_storage_key="vault_v1.pdf",
+            storage_key="vault_v1.pdf",
+            type="pdf",
+            render_status=DocumentVersion.RENDER_READY,
+        )
+        v2 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=2,
+            is_primary=False,
+            file_size=2 * 1024 * 1024,  # 2 MB (> 1 MB dataroom limit)
+            content_type="application/pdf",
+            original_storage_key="vault_v2.pdf",
+            storage_key="vault_v2.pdf",
+            type="pdf",
+            render_status=DocumentVersion.RENDER_READY,
+        )
+
+        with pytest.raises(QuotaExceededError, match="Promoting this version would exceed the Dataroom storage limit"):
+            promote_document_version(doc, v2, user)
+
+    def test_promote_version_in_vault_locks_datarooms_in_stable_order(self, user):
+        """Promoting a version of a vault document must lock affected Datarooms with select_for_update in stable ID order."""
+        from datarooms.models import Dataroom, DataroomDocument
+
+        room1 = Dataroom.objects.create(
+            name="Room 1",
+            organization=user.organization,
+            created_by=user,
+            storage_quota_mb=10,
+            storage_version=2,
+        )
+        room2 = Dataroom.objects.create(
+            name="Room 2",
+            organization=user.organization,
+            created_by=user,
+            storage_quota_mb=10,
+            storage_version=2,
+        )
+
+        root_folder = Folder.objects.create(
+            name="__root__",
+            organization=user.organization,
+            created_by=None,
+            parent=None,
+        )
+        vault_folder = Folder.objects.create(
+            name="__datarooms__",
+            organization=user.organization,
+            created_by=None,
+            parent=root_folder,
+        )
+        room_folder = Folder.objects.create(
+            name="Room_1",
+            organization=user.organization,
+            created_by=None,
+            parent=vault_folder,
+        )
+
+        doc = Document.objects.create(
+            organization=user.organization,
+            created_by=user,
+            folder=room_folder,
+            name="vault_doc.pdf",
+            type="pdf",
+            content_type="application/pdf",
+            file_size=100,
+            status="ready",
+        )
+        DataroomDocument.objects.create(dataroom=room1, document=doc, name="vault_doc.pdf")
+        DataroomDocument.objects.create(dataroom=room2, document=doc, name="vault_doc.pdf")
+
+        v1 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=1,
+            is_primary=True,
+            file_size=100,
+            content_type="application/pdf",
+            original_storage_key="vault_v1.pdf",
+            storage_key="vault_v1.pdf",
+            type="pdf",
+            render_status=DocumentVersion.RENDER_READY,
+        )
+        v2 = DocumentVersion.objects.create(
+            document=doc,
+            version_number=2,
+            is_primary=False,
+            file_size=200,
+            content_type="application/pdf",
+            original_storage_key="vault_v2.pdf",
+            storage_key="vault_v2.pdf",
+            type="pdf",
+            render_status=DocumentVersion.RENDER_READY,
+        )
+
+        original_select_for_update = Dataroom.objects.select_for_update
+        locked_datarooms_fetched = []
+
+        def spy_select_for_update(*args, **kwargs):
+            qs = original_select_for_update(*args, **kwargs)
+            # Wrap the queryset evaluation or save the query
+            original_filter = qs.filter
+            def spy_filter(*f_args, **f_kwargs):
+                sub_qs = original_filter(*f_args, **f_kwargs)
+                original_order_by = sub_qs.order_by
+                def spy_order_by(*o_args, **o_kwargs):
+                    ordered_qs = original_order_by(*o_args, **o_kwargs)
+                    locked_datarooms_fetched.append((list(o_args), list(ordered_qs)))
+                    return ordered_qs
+                sub_qs.order_by = spy_order_by
+                return sub_qs
+            qs.filter = spy_filter
+            return qs
+
+        with patch.object(Dataroom.objects, 'select_for_update', side_effect=spy_select_for_update) as mock_sfu:
+            promote_document_version(doc, v2, user)
+            assert mock_sfu.called, "Dataroom.objects.select_for_update must be called to serialize quota checks"
+            assert len(locked_datarooms_fetched) == 1
+            order_by_args, locked_rooms = locked_datarooms_fetched[0]
+            assert order_by_args == ['id'], "Datarooms must be ordered by 'id' to prevent deadlocks"
+            expected_ids = sorted([room1.id, room2.id])
+            assert [r.id for r in locked_rooms] == expected_ids
+
+
+
 
     def test_check_user_quota_on_upload_respects_custom_quota(self, user):
         """Test that check_user_quota_on_upload respects custom user quota if set, else falls back to global."""

--- a/backend/tests/documents/test_views.py
+++ b/backend/tests/documents/test_views.py
@@ -2001,6 +2001,81 @@ def test_promote_version_endpoint_respects_quota(mock_get_setting, api_client, u
     assert "exceed your storage quota" in response.json()['detail']
 
 
+@pytest.mark.django_db
+@patch('core.services.get_dynamic_setting')
+def test_promote_version_endpoint_vault_document_bypasses_user_quota(mock_get_setting, api_client, user, organization):
+    """Test that promoting a version on a vault document succeeds even when user personal quota is full."""
+    def get_setting_mock(key):
+        if key == 'FILE_SIZE_QUOTA_MB':
+            return 1  # 1 MB quota limit
+        elif key == 'MAX_PREVIEW_FILE_SIZE_MB':
+            return 100
+        elif key == 'MAX_VIDEO_PREVIEW_SIZE_MB':
+            return 100
+        return 0
+    mock_get_setting.side_effect = get_setting_mock
+
+    root_folder = Folder.objects.create(
+        name="__root__",
+        organization=organization,
+        created_by=None,
+        parent=None,
+    )
+    vault_folder = Folder.objects.create(
+        name="__datarooms__",
+        organization=organization,
+        created_by=None,
+        parent=root_folder,
+    )
+    room_folder = Folder.objects.create(
+        name="Room_1",
+        organization=organization,
+        created_by=None,
+        parent=vault_folder,
+    )
+
+    doc = Document.objects.create(
+        name="VaultDoc.pdf",
+        organization=organization,
+        created_by=user,
+        folder=room_folder,
+        status="ready",
+        file_size=500 * 1024,
+    )
+    v1 = DocumentVersion.objects.create(
+        document=doc,
+        version_number=1,
+        is_primary=True,
+        file_size=500 * 1024,
+        content_type="application/pdf",
+        original_storage_key="v1.pdf",
+        storage_key="v1.pdf",
+        type="pdf",
+    )
+    v2 = DocumentVersion.objects.create(
+        document=doc,
+        version_number=2,
+        is_primary=False,
+        file_size=2 * 1024 * 1024,  # 2 MB (> 1 MB user personal quota)
+        content_type="application/pdf",
+        original_storage_key="v2.pdf",
+        storage_key="v2.pdf",
+        type="pdf",
+    )
+    user.total_document_size = 1024 * 1024
+    user.save()
+
+    response = api_client.post(
+        f'/api/v1/documents/{doc.id}/promote_version/',
+        {'version_id': str(v2.id)}
+    )
+    assert response.status_code == status.HTTP_200_OK
+    doc.refresh_from_db()
+    assert doc.file_size == 2 * 1024 * 1024
+    user.refresh_from_db()
+    assert user.total_document_size == 1024 * 1024
+
+
 def test_preview_data_endpoint_document_uploading_state(api_client, user, organization):
     """Test retrieving preview data when document is in uploading state."""
     doc = Document.objects.create(


### PR DESCRIPTION
… on vault document version promotion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault document version promotions now use the associated Dataroom’s storage quota instead of the user’s personal quota.
  * Promoting vault documents no longer increases the user’s personal storage usage.
  * Promotions are blocked when the Dataroom storage limit would be exceeded.
  * Personal document promotions continue to follow existing personal quota rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->