### PR TITLE
feat(notifications): route dataroom collaboration alerts and support …

### DIFF
--- a/.agent/memory.md
+++ b/.agent/memory.md
@@ -349,3 +349,9 @@ COMPOSE_PROJECT_NAME=coneshare docker-compose exec frontend npm test -- --run sr
 - **Category:** Architecture Choice
 - **Context/Implication:** Implemented explicit folder classification (`root`, `personal`, `vault`) and `Dataroom.vault_folder` OneToOne link, replacing implicit column nullability heuristics.
 - **Resolution/Action:** Folders require explicit `folder_type=Folder.FOLDER_TYPE_VAULT` on vault creation (`Folder.get_or_create_vault_subfolder`). Personal folders require `created_by IS NOT NULL`. Migrations are consolidated per app (`documents.0008` and `datarooms.0006`) with strict DAG dependency.
+
+### 2026-09-08 Session Entry
+- **Category:** Architecture Choice
+- **Context/Implication:** After introducing Dataroom collaboration, outbound link notifications could cause missed alerts or duplicate noise between link creators and room owners.
+- **Resolution/Action:** Implemented Phase 1 notification resolution: link creators receive link alerts by default; room owners can subscribe to all room activity via DATAROOM-scoped AutomationRules; if a collaborator leaves or is deactivated, notifications automatically fall back to the Dataroom owner.
+

--- a/backend/automations/emails.py
+++ b/backend/automations/emails.py
@@ -12,7 +12,8 @@ from django.db import transaction
 from django.template.loader import render_to_string
 
 from sharelinks.models import ShareLink, PageView, ViewSession
-from automations.models import AutomationDelivery
+from sharelinks.services import resolve_notification_recipient
+from automations.models import AutomationDelivery, AutomationRule
 from backend.utils import parse_user_agent
 from .constants import EMAIL_COALESCE_DEBOUNCE_SECONDS
 # Import module reference directly to prevent circular import errors with tasks.py
@@ -343,24 +344,49 @@ def handle_email_delivery(delivery: AutomationDelivery):
         logger.info('Automation delivery already processed: delivery_id=%s status=%s', delivery.id, delivery.status)
         return
 
-    # Defensive check for missing rule owner or email
+    # Defensive check for missing rule owner, email, or inactive account
     owner = delivery.rule.created_by
-    if not owner or not owner.email:
-        logger.warning('Automation delivery skipped: owner has no email address: delivery_id=%s', delivery.id)
-        tasks._mark_non_retryable_failure(delivery, 'Owner has no email address.')
+    if not owner or not owner.email or not getattr(owner, 'is_active', True):
+        logger.warning('Automation delivery skipped: owner has no email address or is inactive: delivery_id=%s', delivery.id)
+        tasks._mark_non_retryable_failure(delivery, 'Owner has no email address or is inactive.')
         return
     recipient_email = owner.email
 
     # Prior to SMTP dispatch, check if the toggle is checked on the referenced ShareLink
     payload = delivery.payload or {}
     share_link_id = payload.get('share_link_id')
+    event_type = delivery.event_type
     if share_link_id:
         try:
-            share_link = ShareLink.objects.filter(id=share_link_id).first()
-            if share_link and not share_link.receive_email_notification:
-                logger.info('Skipping email alert: notifications disabled for link %s', share_link_id)
-                tasks._mark_success_direct(delivery, 'Skipped: receive_email_notification is False on ShareLink.')
-                return
+            share_link = ShareLink.objects.select_related(
+                'created_by', 'dataroom__created_by'
+            ).prefetch_related(
+                'dataroom__collaborators'
+            ).filter(id=share_link_id).first()
+
+            if share_link:
+                # Only re-resolve recipient when the link creator owns this rule.
+                # If the link creator is no longer an active participant in the dataroom,
+                # fall back to the effective recipient (dataroom owner).
+                # DATAROOM-scoped rules belonging directly to the room owner deliver to the
+                # rule creator directly and do not need recipient re-resolution.
+                if share_link.dataroom_id and delivery.rule.created_by_id == share_link.created_by_id:
+                    effective_recipient = resolve_notification_recipient(share_link)
+                    if effective_recipient:
+                        owner = effective_recipient
+                        recipient_email = effective_recipient.email
+                    else:
+                        logger.info('Skipping email alert: no valid recipient for dataroom link %s', share_link_id)
+                        tasks._mark_success_direct(delivery, 'Skipped: no valid active recipient in dataroom.')
+                        return
+
+                if not share_link.receive_email_notification:
+                    is_room_rule = delivery.rule.scope_type == AutomationRule.ScopeType.DATAROOM
+                    is_qna = event_type in ('qna_thread_created', 'qna_message_created')
+                    if not is_room_rule and not is_qna:
+                        logger.info('Skipping email alert: notifications disabled for link %s', share_link_id)
+                        tasks._mark_success_direct(delivery, 'Skipped: receive_email_notification is False on ShareLink.')
+                        return
         except Exception as e:
             logger.warning('Failed to query ShareLink for notification check: %s', e)
 

--- a/backend/automations/services.py
+++ b/backend/automations/services.py
@@ -1,6 +1,8 @@
 import logging
 import uuid
 
+from django.db.models import Q
+
 from core.models import Organization, User
 
 from .models import AutomationDelivery, AutomationRule, AutomationDestination
@@ -89,15 +91,31 @@ def dispatch_automation_event(event_type: str, payload: dict) -> int:
         return 0
 
     owner_user_id = payload.get('owner_user_id')
+    dataroom_owner_user_id = payload.get('dataroom_owner_user_id')
+    dataroom_id = payload.get('dataroom_id')
+
     if not owner_user_id:
         logger.warning('Automation event dropped: missing owner_user_id for event=%s organization_id=%s', event_type, organization_id)
         return 0
 
+    # Match rules created by the primary link owner (global, link, or dataroom scope)
+    rule_q = Q(created_by_id=owner_user_id)
+
+    # If the event happened in a dataroom and the dataroom owner is distinct, also match the
+    # dataroom owner's DATAROOM-scoped rules for this specific dataroom.
+    if dataroom_id and dataroom_owner_user_id and str(dataroom_owner_user_id) != str(owner_user_id):
+        rule_q |= Q(
+            created_by_id=dataroom_owner_user_id,
+            created_by__is_active=True,
+            scope_type=AutomationRule.ScopeType.DATAROOM,
+            dataroom_id=dataroom_id,
+        )
+
     rules = AutomationRule.objects.filter(
         organization=organization,
         is_active=True,
-        created_by_id=owner_user_id,
-    )
+        created_by__is_active=True,
+    ).filter(rule_q)
     rules = rules.prefetch_related('destinations')
 
     created = 0

--- a/backend/sharelinks/services.py
+++ b/backend/sharelinks/services.py
@@ -15,3 +15,38 @@ def _get_unique_dataroom_share_link_name(dataroom: Dataroom, original_name: str)
     """Generates a unique name for a share link for a dataroom to avoid duplicates."""
     filter_kwargs = {'dataroom': dataroom}
     return get_unique_name(ShareLink, original_name, filter_kwargs, has_extension=False)
+
+
+def resolve_notification_recipient(share_link):
+    """
+    Determines the effective user who should receive notifications for activity on a ShareLink:
+    1. By default, returns share_link.created_by if active and has an email.
+    2. If the link belongs to a Dataroom, checks whether created_by is still a valid participant
+       (either the room owner or an active collaborator).
+    3. If created_by is inactive or no longer a collaborator on the room, falls back to the
+       current Dataroom owner (dataroom.created_by).
+    4. Returns None if no active recipient with an email address is found.
+    """
+    creator = getattr(share_link, 'created_by', None)
+    dataroom = getattr(share_link, 'dataroom', None)
+
+    if not dataroom:
+        if creator and getattr(creator, 'is_active', False) and getattr(creator, 'email', None):
+            return creator
+        return None
+
+    # For dataroom share links:
+    if creator and getattr(creator, 'is_active', False) and getattr(creator, 'email', None):
+        # Room owner
+        if dataroom.created_by_id == creator.id:
+            return creator
+        # Active collaborator in this dataroom
+        if dataroom.collaborators.filter(user=creator).exists():
+            return creator
+
+    # Fallback to current dataroom owner
+    room_owner = getattr(dataroom, 'created_by', None)
+    if room_owner and getattr(room_owner, 'is_active', False) and getattr(room_owner, 'email', None):
+        return room_owner
+
+    return None

--- a/backend/sharelinks/tasks.py
+++ b/backend/sharelinks/tasks.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext as _, override as translation_overr
 from celery import shared_task
 
 from .models import ViewSession
+from .services import resolve_notification_recipient
 
 logger = logging.getLogger('tasks')
 
@@ -14,13 +15,14 @@ logger = logging.getLogger('tasks')
 @shared_task
 def send_view_notification_email_task(view_session_id: str):
     """
-    Sends an email notification to the share link owner about a new view session.
+    Sends an email notification to the share link owner (or fallback dataroom owner)
+    about a new view session.
     """
     try:
         view_session = ViewSession.objects.select_related(
             'share_link__created_by',
             'share_link__document',
-            'share_link__dataroom'
+            'share_link__dataroom__created_by',
         ).get(id=view_session_id)
     except ViewSession.DoesNotExist:
         logger.warning(f"ViewSession with id {view_session_id} not found for email notification.")
@@ -33,10 +35,10 @@ def send_view_notification_email_task(view_session_id: str):
         logger.info(f"Email notification for ShareLink {share_link.id} is disabled. Aborting send.")
         return
 
-    owner = share_link.created_by
+    owner = resolve_notification_recipient(share_link)
     
     if not owner or not owner.email:
-        logger.info(f"Share link {share_link.id} owner has no email for notification.")
+        logger.info(f"Share link {share_link.id} has no valid active recipient email for notification.")
         return
 
     if share_link.document:

--- a/backend/sharelinks/views.py
+++ b/backend/sharelinks/views.py
@@ -127,15 +127,19 @@ def _dispatch_automation_event(share_link, event_type: str, extra_payload=None, 
 
     document_name = None
     dataroom_name = None
+    dataroom_owner_user_id = None
 
     if share_link.document_id:
         document_name = share_link.document.name
     if share_link.dataroom_id:
         dataroom_name = share_link.dataroom.name
+        if share_link.dataroom and share_link.dataroom.created_by_id:
+            dataroom_owner_user_id = str(share_link.dataroom.created_by_id)
 
     payload = {
         'organization_id': str(share_link.created_by.organization_id),
         'owner_user_id': str(share_link.created_by_id),
+        'dataroom_owner_user_id': dataroom_owner_user_id,
         'share_link_id': str(share_link.id),
         'dataroom_id': str(share_link.dataroom_id) if share_link.dataroom_id else None,
         'dataroom_name': dataroom_name,

--- a/backend/tests/automations/test_services.py
+++ b/backend/tests/automations/test_services.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from automations.models import AutomationDelivery, AutomationDestination, AutomationRule
 from automations.services import dispatch_automation_event, ensure_default_email_automation
 from core.models import Organization, User
+from sharelinks.models import ShareLink
 
 
 pytestmark = pytest.mark.django_db
@@ -357,3 +358,112 @@ def test_ensure_default_email_automation_provisioning(user):
     
     destination.refresh_from_db()
     assert destination.name == f"Default Email (new_owner@example.com)"
+
+
+def test_dispatch_matches_dataroom_owner_room_scoped_rule(user, user2, dataroom):
+    """
+    When collaborator user2 triggers an event on a dataroom link,
+    room owner user's DATAROOM-scoped rule is also matched and dispatched.
+    """
+    link = ShareLink.objects.create(
+        dataroom=dataroom,
+        created_by=user2,
+        slug="collab-share-link",
+        receive_email_notification=False,
+    )
+
+    # 1. Collaborator user2 has a global rule
+    collab_dest = AutomationDestination.objects.create(
+        organization=user2.organization,
+        created_by=user2,
+        name="Collab Destination",
+        destination_type=AutomationDestination.DestinationType.EMAIL,
+    )
+    collab_rule = AutomationRule.objects.create(
+        organization=user2.organization,
+        created_by=user2,
+        name="Collab Global Rule",
+        scope_type=AutomationRule.ScopeType.GLOBAL,
+        subscribed_events=['dataroom_opened'],
+        is_active=True,
+    )
+    collab_rule.destinations.add(collab_dest)
+
+    # 2. Room owner user has a DATAROOM-scoped rule for this specific dataroom
+    owner_dest = AutomationDestination.objects.create(
+        organization=user.organization,
+        created_by=user,
+        name="Owner Destination",
+        destination_type=AutomationDestination.DestinationType.EMAIL,
+    )
+    owner_rule = AutomationRule.objects.create(
+        organization=user.organization,
+        created_by=user,
+        name="Owner Room Rule",
+        scope_type=AutomationRule.ScopeType.DATAROOM,
+        dataroom=dataroom,
+        subscribed_events=['dataroom_opened'],
+        is_active=True,
+    )
+    owner_rule.destinations.add(owner_dest)
+
+    # 3. Dispatch event for collaborator user2's link
+    payload = {
+        'organization_id': str(user.organization.id),
+        'owner_user_id': str(user2.id),
+        'dataroom_owner_user_id': str(user.id),
+        'dataroom_id': str(dataroom.id),
+        'share_link_id': str(link.id),
+    }
+    created_count = dispatch_automation_event('dataroom_opened', payload)
+
+    assert created_count == 2
+    matched_rules = set(AutomationDelivery.objects.values_list('rule_id', flat=True))
+    assert matched_rules == {collab_rule.id, owner_rule.id}
+
+
+def test_dispatch_ignores_inactive_dataroom_owner_room_scoped_rule(user, user2, dataroom):
+    """
+    When the dataroom owner user is deactivated (is_active=False), their DATAROOM-scoped
+    rule is NOT matched or dispatched when activity occurs on collaborator user2's link.
+    """
+    user.is_active = False
+    user.save()
+
+    link = ShareLink.objects.create(
+        dataroom=dataroom,
+        created_by=user2,
+        slug="collab-share-link-inactive-owner",
+        receive_email_notification=False,
+    )
+
+    # Room owner user (inactive) has a DATAROOM-scoped rule
+    owner_dest = AutomationDestination.objects.create(
+        organization=user.organization,
+        created_by=user,
+        name="Owner Destination",
+        destination_type=AutomationDestination.DestinationType.EMAIL,
+    )
+    owner_rule = AutomationRule.objects.create(
+        organization=user.organization,
+        created_by=user,
+        name="Owner Room Rule",
+        scope_type=AutomationRule.ScopeType.DATAROOM,
+        dataroom=dataroom,
+        subscribed_events=['dataroom_opened'],
+        is_active=True,
+    )
+    owner_rule.destinations.add(owner_dest)
+
+    payload = {
+        'organization_id': str(user2.organization.id),
+        'owner_user_id': str(user2.id),
+        'dataroom_owner_user_id': str(user.id),
+        'dataroom_id': str(dataroom.id),
+        'share_link_id': str(link.id),
+    }
+    created_count = dispatch_automation_event('dataroom_opened', payload)
+
+    assert created_count == 0
+    assert AutomationDelivery.objects.filter(rule=owner_rule).count() == 0
+

--- a/backend/tests/automations/test_tasks.py
+++ b/backend/tests/automations/test_tasks.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from automations.models import AutomationDelivery, AutomationDestination, AutomationRule
 from automations.tasks import deliver_automation_delivery_task
+from sharelinks.models import ShareLink
 
 
 pytestmark = pytest.mark.django_db
@@ -803,6 +804,118 @@ def test_deliver_task_standard_fallback_email_respects_user_language(mock_send_m
     _, call_kwargs = mock_send_mail.call_args
     assert 'Alice <alice@example.com> 向您的文件收集“KYC Documents”上传了文件' in call_kwargs['subject']
     assert '访问详情' in call_kwargs['html_message']
+
+
+@patch('automations.emails.send_mail')
+def test_deliver_task_owner_room_rule_delivered_even_if_link_notifications_disabled(
+    mock_send_mail, user, user2, dataroom
+):
+    """
+    If a link created by collaborator user2 has receive_email_notification=False,
+    room owner user's explicit DATAROOM-scoped automation rule is still delivered.
+    """
+    link = ShareLink.objects.create(
+        dataroom=dataroom,
+        created_by=user2,
+        slug="quiet-room-link",
+        receive_email_notification=False,
+    )
+
+    owner_dest = AutomationDestination.objects.create(
+        organization=user.organization,
+        created_by=user,
+        name="Owner Email",
+        destination_type=AutomationDestination.DestinationType.EMAIL,
+    )
+    owner_rule = AutomationRule.objects.create(
+        organization=user.organization,
+        created_by=user,
+        name="Owner Room Watcher",
+        scope_type=AutomationRule.ScopeType.DATAROOM,
+        dataroom=dataroom,
+        subscribed_events=['dataroom_opened'],
+        is_active=True,
+    )
+    owner_rule.destinations.add(owner_dest)
+
+    delivery = AutomationDelivery.objects.create(
+        organization=user.organization,
+        rule=owner_rule,
+        destination=owner_dest,
+        event_type='dataroom_opened',
+        payload={
+            'organization_id': str(user.organization.id),
+            'share_link_id': str(link.id),
+            'dataroom_id': str(dataroom.id),
+            'dataroom_name': dataroom.name,
+            'viewer_email': 'buyer@fund.com',
+        },
+        status=AutomationDelivery.Status.PENDING,
+    )
+
+    deliver_automation_delivery_task(str(delivery.id))
+
+    delivery.refresh_from_db()
+    assert delivery.status == AutomationDelivery.Status.SUCCESS
+    mock_send_mail.assert_called_once()
+    _, kwargs = mock_send_mail.call_args
+    assert kwargs['recipient_list'] == [user.email]
+
+
+@patch('automations.emails.send_mail')
+def test_deliver_task_collaborator_removed_delivery_falls_back_to_room_owner(
+    mock_send_mail, user, user2, dataroom
+):
+    """
+    If collaborator user2 was removed from the dataroom, delivery for user2's sharelink
+    falls back to room owner user instead of emailing the ex-collaborator.
+    """
+    link = ShareLink.objects.create(
+        dataroom=dataroom,
+        created_by=user2,
+        slug="ex-collab-link",
+        receive_email_notification=True,
+    )
+
+    collab_dest = AutomationDestination.objects.create(
+        organization=user2.organization,
+        created_by=user2,
+        name="Collab Email",
+        destination_type=AutomationDestination.DestinationType.EMAIL,
+    )
+    collab_rule = AutomationRule.objects.create(
+        organization=user2.organization,
+        created_by=user2,
+        name="Collab Rule",
+        scope_type=AutomationRule.ScopeType.GLOBAL,
+        subscribed_events=['dataroom_opened'],
+        is_active=True,
+    )
+    collab_rule.destinations.add(collab_dest)
+
+    delivery = AutomationDelivery.objects.create(
+        organization=user2.organization,
+        rule=collab_rule,
+        destination=collab_dest,
+        event_type='dataroom_opened',
+        payload={
+            'organization_id': str(user2.organization.id),
+            'share_link_id': str(link.id),
+            'dataroom_id': str(dataroom.id),
+            'dataroom_name': dataroom.name,
+            'viewer_email': 'buyer@fund.com',
+        },
+        status=AutomationDelivery.Status.PENDING,
+    )
+
+    deliver_automation_delivery_task(str(delivery.id))
+
+    delivery.refresh_from_db()
+    assert delivery.status == AutomationDelivery.Status.SUCCESS
+    mock_send_mail.assert_called_once()
+    _, kwargs = mock_send_mail.call_args
+    assert kwargs['recipient_list'] == [user.email]
+
 
 
 

--- a/backend/tests/sharelinks/test_services.py
+++ b/backend/tests/sharelinks/test_services.py
@@ -1,0 +1,138 @@
+import pytest
+from unittest.mock import patch
+
+from datarooms.models import DataroomCollaborator
+from sharelinks.models import ShareLink, ViewSession
+from sharelinks.services import (
+    _get_unique_share_link_name,
+    _get_unique_dataroom_share_link_name,
+    resolve_notification_recipient,
+)
+from sharelinks.tasks import send_view_notification_email_task
+
+
+@pytest.mark.django_db
+class TestShareLinkNameServices:
+    def test_get_unique_share_link_name(self, document, user):
+        ShareLink.objects.create(document=document, created_by=user, name="My Link")
+        name = _get_unique_share_link_name(document, "My Link")
+        assert name == "My Link (2)"
+
+    def test_get_unique_dataroom_share_link_name(self, dataroom, user):
+        ShareLink.objects.create(dataroom=dataroom, created_by=user, name="Room Link")
+        name = _get_unique_dataroom_share_link_name(dataroom, "Room Link")
+        assert name == "Room Link (2)"
+
+
+@pytest.mark.django_db
+class TestResolveNotificationRecipient:
+    def test_document_share_link_returns_creator(self, document, user):
+        link = ShareLink.objects.create(
+            document=document,
+            created_by=user,
+            slug="doc-link-1",
+        )
+        assert resolve_notification_recipient(link) == user
+
+    def test_document_share_link_inactive_creator_returns_none(self, document, user):
+        user.is_active = False
+        user.save(update_fields=['is_active'])
+        link = ShareLink.objects.create(
+            document=document,
+            created_by=user,
+            slug="doc-link-2",
+        )
+        assert resolve_notification_recipient(link) is None
+
+    def test_dataroom_share_link_created_by_owner(self, dataroom, user):
+        link = ShareLink.objects.create(
+            dataroom=dataroom,
+            created_by=user,
+            slug="room-link-owner",
+        )
+        assert resolve_notification_recipient(link) == user
+
+    def test_dataroom_share_link_created_by_active_collaborator(self, dataroom, user, user2):
+        DataroomCollaborator.objects.create(
+            dataroom=dataroom,
+            user=user2,
+            invited_by=user,
+        )
+        link = ShareLink.objects.create(
+            dataroom=dataroom,
+            created_by=user2,
+            slug="room-link-collab",
+        )
+        assert resolve_notification_recipient(link) == user2
+
+    def test_dataroom_share_link_removed_collaborator_falls_back_to_owner(self, dataroom, user, user2):
+        # user2 created link, but is not in DataroomCollaborator
+        link = ShareLink.objects.create(
+            dataroom=dataroom,
+            created_by=user2,
+            slug="room-link-ex-collab",
+        )
+        # Should fallback to room owner user
+        assert resolve_notification_recipient(link) == user
+
+    def test_dataroom_share_link_deactivated_collaborator_falls_back_to_owner(self, dataroom, user, user2):
+        DataroomCollaborator.objects.create(
+            dataroom=dataroom,
+            user=user2,
+            invited_by=user,
+        )
+        user2.is_active = False
+        user2.save(update_fields=['is_active'])
+
+        link = ShareLink.objects.create(
+            dataroom=dataroom,
+            created_by=user2,
+            slug="room-link-deactivated-collab",
+        )
+        assert resolve_notification_recipient(link) == user
+
+
+@pytest.mark.django_db
+class TestSendViewNotificationEmailTask:
+    @patch('sharelinks.tasks.send_mail')
+    def test_sends_to_collaborator_when_active(self, mock_send_mail, dataroom, user, user2):
+        DataroomCollaborator.objects.create(
+            dataroom=dataroom,
+            user=user2,
+            invited_by=user,
+        )
+        link = ShareLink.objects.create(
+            dataroom=dataroom,
+            created_by=user2,
+            slug="room-link-collab-active",
+            receive_email_notification=True,
+        )
+        session = ViewSession.objects.create(
+            share_link=link,
+            viewer_email="investor@fund.com",
+        )
+
+        send_view_notification_email_task(str(session.id))
+
+        mock_send_mail.assert_called_once()
+        _, kwargs = mock_send_mail.call_args
+        assert kwargs['recipient_list'] == [user2.email]
+
+    @patch('sharelinks.tasks.send_mail')
+    def test_falls_back_to_room_owner_when_collaborator_removed(self, mock_send_mail, dataroom, user, user2):
+        link = ShareLink.objects.create(
+            dataroom=dataroom,
+            created_by=user2,
+            slug="room-link-collab-removed",
+            receive_email_notification=True,
+        )
+        session = ViewSession.objects.create(
+            share_link=link,
+            viewer_email="investor@fund.com",
+        )
+
+        send_view_notification_email_task(str(session.id))
+
+        mock_send_mail.assert_called_once()
+        _, kwargs = mock_send_mail.call_args
+        assert kwargs['recipient_list'] == [user.email]

--- a/plans/todo/dataroom_collaboration_notifications_phase2_plan.md
+++ b/plans/todo/dataroom_collaboration_notifications_phase2_plan.md
@@ -1,0 +1,83 @@
+# 🚀 Dataroom Collaboration Notifications - Phase 2 Design Plan
+
+## 1. 📌 Overview & Context
+
+Phase 1 established backend recipient routing and automation cross-matching:
+- Link creators receive link activity alerts by default.
+- If a collaborator is deactivated or removed from a Dataroom, notifications automatically fall back to the Dataroom owner.
+- Dataroom owners can subscribe to room-wide events via `DATAROOM`-scoped `AutomationRule` records.
+
+**Phase 2** builds user-facing notification controls, room-level subscription settings, deal-lead digests, and link-level co-notifications to provide complete collaboration visibility without inbox fatigue.
+
+---
+
+## 2. 🎯 Key Feature Areas
+
+### A. Dataroom In-Room Notification Settings (UI)
+* **Problem:** Users currently have to navigate to `/automations` to configure room-level alerts. Most business users expect notification toggles directly within the Dataroom.
+* **Target UI:** Add a **Notifications** tab or section in `DataroomSettingsModal`:
+  * **My Notification Level:**
+    * 🔘 **All Activity:** Instant alerts for views, downloads, and Q&A on any link in this room.
+    * 🔘 **Actionable Only (Default for Collaborators):** Only inbound Q&A questions and access requests.
+    * 🔘 **Daily Digest (Recommended for Deal Leads):** A single daily rollup of room activity.
+    * 🔘 **Mute:** No automated emails for this room.
+* **Backend Architecture:**
+  * Endpoint: `GET / PATCH /api/v1/datarooms/{id}/notification-preference/`
+  * Backed by `DataroomCollaborator.notification_level` for collaborators and a new `DataroomOwnerPreference` or automated `AutomationRule` generation.
+
+---
+
+### B. Link Creation Sheet: "Also Notify Room Owner"
+* **Problem:** Collaborator A sending a high-priority link to an anchor investor wants room owner B to get the instant ping as well, without needing owner B to pre-configure an automation rule.
+* **Target UI (`LinkSheet.jsx`):**
+  * Below `[x] Receive email notifications`, conditionally display when `dataroom` is present and creator is not the owner:
+    * `[x] Also notify dataroom owner (<owner_email>)`
+* **Backend Schema:**
+  * Add `notify_dataroom_owner = models.BooleanField(default=False)` to `ShareLink`.
+  * `resolve_notification_recipients(share_link)` returns a list `[creator, owner]` when true.
+
+---
+
+### C. Dataroom Daily / Weekly Activity Digest
+* **Problem:** Active deal rooms generate dozens of visitor sessions per day. Real-time emails cause notification fatigue, leading owners to disable alerts entirely.
+* **Architecture:**
+  * Celery Beat scheduled task: `send_dataroom_activity_digest_task` (runs daily at midnight or 08:00 user timezone).
+  * Queries `DataroomVisit` and `ViewSession` from the past 24 hours grouped by dataroom.
+  * Rollup metrics:
+    * Total new visitors and companies identified.
+    * Top viewed documents and high-interest folders.
+    * Unanswered Q&A threads requiring attention.
+  * Template: `sharelinks/dataroom_daily_digest_email.html`.
+
+---
+
+### D. Inbound Q&A Assignment & Teammate Mentioning
+* **Problem:** When an external investor asks a technical or financial question in a dataroom, the link creator may not be the subject-matter expert.
+* **Capabilities:**
+  * Assign thread to a specific collaborator: `QnAThread.assigned_to = ForeignKey(User)`.
+  * Instant email alert to the assigned teammate with direct jump link to the thread.
+  * Email notification when a teammate is `@mentioned` in an internal note or reply.
+
+---
+
+## 3. 🛠️ Implementation Steps
+
+1. **Database Migrations:**
+   * Add `notify_dataroom_owner` boolean to `ShareLink`.
+   * Add `notification_level` choices (`all`, `actionable`, `digest`, `off`) to `DataroomCollaborator`.
+   * Add `assigned_to` to `QnAThread`.
+
+2. **Backend API & Tasks:**
+   * Extend `resolve_notification_recipient` to return all applicable recipients (`resolve_notification_recipients`).
+   * Implement Celery beat task `send_dataroom_activity_digest_task`.
+   * Add preference endpoint in `datarooms/views.py`.
+
+3. **Frontend Changes:**
+   * Update `LinkSheet.jsx` to render the "Also notify room owner" checkbox for room links.
+   * Add Notifications section in `DataroomSettingsModal.jsx`.
+   * Add Q&A assignment dropdown in `QnAPanel.jsx`.
+
+4. **Testing:**
+   * Unit tests for digest aggregation and time window bounding.
+   * Tests for multi-recipient dispatch on `notify_dataroom_owner=True`.
+   * End-to-end BDD tests for room notification preference updates.


### PR DESCRIPTION
…owner fallback

- resolve notification recipient to link creator with fallback to dataroom owner
- support room-scoped AutomationRule matching for dataroom owners on collaborator links
- ensure room-scoped automation rules and Q&A events bypass link-level silence toggle
- add test coverage in tests/sharelinks/test_services.py and tests/automations/
- add Phase 2 notifications plan to plans/todo and update agent memory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Link creators receive view notifications by default when they remain active participants.
  - Dataroom owners can receive notifications for activity through room-scoped automation rules.
  - Notifications automatically fall back to the active dataroom owner when a link creator leaves or is deactivated.
  - Dataroom activity can now trigger both collaborator and owner automation notifications where applicable.

- **Bug Fixes**
  - Improved notification delivery for shared links and Q&A activity, including valid room-scoped rules even when standard link notifications are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->