### PR TITLE
fix(frontend): prevent table header text wrapping and stabilize colum…

### DIFF
--- a/frontend/src/components/documents/LinksTable.jsx
+++ b/frontend/src/components/documents/LinksTable.jsx
@@ -53,7 +53,7 @@ function CopyableLink({ slug, isExpired, expires_at }) {
       <Tooltip>
         <TooltipTrigger asChild>
           <div
-            className="relative w-full cursor-not-allowed rounded px-1 py-0.5 text-left text-sm text-gray-400"
+            className="relative w-full max-w-[220px] cursor-not-allowed rounded px-1 py-0.5 text-left text-sm text-gray-400"
             title={url}
           >
             <span className="block truncate">{displayUrl}</span>
@@ -74,7 +74,7 @@ function CopyableLink({ slug, isExpired, expires_at }) {
       <TooltipTrigger asChild>
         <div
           onClick={handleCopy}
-          className="w-full cursor-pointer rounded px-1 py-0.5 text-left text-sm text-gray-600 transition-colors hover:bg-gray-100"
+          className="w-full max-w-[220px] cursor-pointer rounded px-1 py-0.5 text-left text-sm text-gray-600 transition-colors hover:bg-gray-100"
           title={url}
           data-testid={`copyable-link-div-${slug}`}
         >
@@ -141,20 +141,20 @@ export function LinksTable({
       <div>
         {!isDashboardWidget && <h2 className="text-xl font-semibold">{t('analytics.shareLinks')}</h2>}
       <div className="mt-4 overflow-hidden rounded-lg border">
-        <Table>
+        <Table className={isDashboardWidget ? 'min-w-[900px]' : 'min-w-[750px]'}>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-8" />
-              <TableHead>{t('analytics.name')}</TableHead>
-              <TableHead>{t('analytics.link')}</TableHead>
-              {isDashboardWidget && <TableHead>{t('analytics.document')}</TableHead>}
-              <TableHead>{t('analytics.visits')}</TableHead>
-              <TableHead>{t('analytics.created')}</TableHead>
-              <TableHead>{t('analytics.viewedAt')}</TableHead>
-              <TableHead>{t('analytics.settings')}</TableHead>
-              {!isDashboardWidget && <TableHead>{t('analytics.status')}</TableHead>}
+              <TableHead className="w-8 px-2" />
+              <TableHead className="min-w-[140px] max-w-[200px] whitespace-nowrap">{t('analytics.name')}</TableHead>
+              <TableHead className="min-w-[160px] max-w-[220px] whitespace-nowrap">{t('analytics.link')}</TableHead>
+              {isDashboardWidget && <TableHead className="min-w-[160px] max-w-[240px] whitespace-nowrap">{t('analytics.document')}</TableHead>}
+              <TableHead className="w-20 whitespace-nowrap">{t('analytics.visits')}</TableHead>
+              <TableHead className="w-28 whitespace-nowrap">{t('analytics.created')}</TableHead>
+              <TableHead className="w-28 whitespace-nowrap">{t('analytics.viewedAt')}</TableHead>
+              <TableHead className="w-28 whitespace-nowrap">{t('analytics.settings')}</TableHead>
+              {!isDashboardWidget && <TableHead className="w-24 whitespace-nowrap">{t('analytics.status')}</TableHead>}
               {!isDashboardWidget && (
-                <TableHead>
+                <TableHead className="w-20 text-right whitespace-nowrap">
                   <span className="sr-only">{t('common.actions')}</span>
                 </TableHead>
               )}
@@ -168,7 +168,7 @@ export function LinksTable({
               return (
                 <Fragment key={link.id}>
                   <TableRow>
-                    <TableCell>
+                    <TableCell className="w-8 px-2">
                       {hasViews && (
                         <button
                           onClick={() => setExpandedRowId(isExpanded ? null : link.id)}
@@ -184,17 +184,19 @@ export function LinksTable({
                         </button>
                       )}
                     </TableCell>
-                    <TableCell className="font-medium">
-                      <div className="flex items-center gap-2">
-                        <span>{link.name || t('links.untitledLink')}</span>
+                    <TableCell className="font-medium min-w-[140px] max-w-[200px]">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="truncate" title={link.name || t('links.untitledLink')}>
+                          {link.name || t('links.untitledLink')}
+                        </span>
                         {isExpired && (
-                          <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">
+                          <span className="shrink-0 rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">
                             {t('analytics.expired')}
                           </span>
                         )}
                       </div>
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="min-w-[160px] max-w-[220px]">
                       <CopyableLink
                         slug={link.slug}
                         isExpired={isExpired}
@@ -202,43 +204,43 @@ export function LinksTable({
                       />
                     </TableCell>
                     {isDashboardWidget && (
-                      <TableCell>
+                      <TableCell className="min-w-[160px] max-w-[240px]">
                         {link.document ? (
                           <Link
                             to={`/documents/${link.document}`}
-                            className="inline-flex items-center gap-1.5 truncate hover:underline"
+                            className="inline-flex items-center gap-1.5 max-w-full hover:underline"
                             title={link.document_name}
                           >
-                            <FileTypeIcon type={link.document_type} className="h-4 w-4" />
-                            <span>{link.document_name}</span>
+                            <FileTypeIcon type={link.document_type} className="h-4 w-4 shrink-0" />
+                            <span className="truncate">{link.document_name}</span>
                           </Link>
                         ) : link.dataroom ? (
                           <Link
                             to={`/datarooms/${link.dataroom}`}
-                            className="inline-flex items-center gap-1.5 truncate hover:underline"
+                            className="inline-flex items-center gap-1.5 max-w-full hover:underline"
                             title={link.dataroom_name}
                           >
-                            <FolderIcon className="h-4 w-4 text-blue-500" />
-                            <span>{link.dataroom_name}</span>
+                            <FolderIcon className="h-4 w-4 text-blue-500 shrink-0" />
+                            <span className="truncate">{link.dataroom_name}</span>
                           </Link>
                         ) : (
                           <span className="text-gray-400">—</span>
                         )}
                       </TableCell>
                     )}
-                    <TableCell>{link.view_count}</TableCell>
-                    <TableCell>{formatDate(link.created_at, 'PP')}</TableCell>
-                    <TableCell>
+                    <TableCell className="w-20 whitespace-nowrap">{link.view_count}</TableCell>
+                    <TableCell className="w-28 whitespace-nowrap text-muted-foreground">{formatDate(link.created_at, 'PP')}</TableCell>
+                    <TableCell className="w-28 whitespace-nowrap text-muted-foreground">
                       {link.last_viewed_at
                         ? formatDate(link.last_viewed_at, 'PP')
                         : '—'}
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="w-28 whitespace-nowrap">
                       <LinkSettingsSummary link={link} onClick={() => onEditLink(link)} />
                     </TableCell>
                     {!isDashboardWidget && (
                       <>
-                        <TableCell>
+                        <TableCell className="w-24 whitespace-nowrap">
                           <Tooltip>
                             <TooltipTrigger asChild>
                               {/* Wrap Switch in a span to resolve event conflicts with TooltipTrigger */}
@@ -255,7 +257,7 @@ export function LinksTable({
                             </TooltipContent>
                           </Tooltip>
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell className="w-20 text-right whitespace-nowrap">
                           <LinkActionsDropdown
                             link={link}
                             onPreview={handlePreview}

--- a/frontend/src/components/documents/ViewSessionsTable.jsx
+++ b/frontend/src/components/documents/ViewSessionsTable.jsx
@@ -206,17 +206,17 @@ export function ViewSessionsTable({ views, totalCount, loading, currentPage, onP
       <div>
         {!isDashboardWidget && <h2 className="text-xl font-semibold">{t('analytics.viewSessions')}</h2>}
         <div className="mt-4 overflow-hidden rounded-lg border">
-          <Table>
+          <Table className={isDashboardWidget ? 'min-w-[950px]' : 'min-w-[750px]'}>
             <TableHeader>
               <TableRow>
-                <TableHead className="w-8" />
-                <TableHead>{t('analytics.visitor')}</TableHead>
-                <TableHead>{t('analytics.link')}</TableHead>
-                {isDashboardWidget && <TableHead>{t('analytics.document')}</TableHead>}
-                <TableHead>{t('analytics.viewedAt')}</TableHead>
-                <TableHead>{t('analytics.downloadedAt')}</TableHead>
-                <TableHead className="text-right">{t('analytics.duration')}</TableHead>
-                <TableHead className="text-right">{t('analytics.completion')}</TableHead>
+                <TableHead className="w-8 px-2" />
+                <TableHead className="min-w-[160px] max-w-[220px] whitespace-nowrap">{t('analytics.visitor')}</TableHead>
+                <TableHead className="min-w-[130px] max-w-[180px] whitespace-nowrap">{t('analytics.link')}</TableHead>
+                {isDashboardWidget && <TableHead className="min-w-[150px] max-w-[220px] whitespace-nowrap">{t('analytics.document')}</TableHead>}
+                <TableHead className="w-36 whitespace-nowrap">{t('analytics.viewedAt')}</TableHead>
+                <TableHead className="w-36 whitespace-nowrap">{t('analytics.downloadedAt')}</TableHead>
+                <TableHead className="w-24 text-right whitespace-nowrap">{t('analytics.duration')}</TableHead>
+                <TableHead className="w-24 text-right whitespace-nowrap">{t('analytics.completion')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -234,7 +234,7 @@ export function ViewSessionsTable({ views, totalCount, loading, currentPage, onP
                 return (
                   <Fragment key={view.id}>
                     <TableRow>
-                      <TableCell>
+                      <TableCell className="w-8 px-2">
                         {isExpandable && (
                           <button
                             onClick={() => setExpandedRowId(isExpanded ? null : view.id)}
@@ -250,16 +250,21 @@ export function ViewSessionsTable({ views, totalCount, loading, currentPage, onP
                           </button>
                         )}
                       </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2 font-medium">
-                          <span>{view.viewer_email || t('viewSessions.anonymous')}</span>
+                      <TableCell className="min-w-[160px] max-w-[220px]">
+                        <div className="flex items-center gap-2 font-medium min-w-0">
+                          <span className="truncate" title={view.viewer_email || t('viewSessions.anonymous')}>
+                            {view.viewer_email || t('viewSessions.anonymous')}
+                          </span>
                           {view.is_owner_view && (
-                            <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-800">
+                            <span className="shrink-0 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-800">
                               {t('viewSessions.you')}
                             </span>
                           )}
                         </div>
-                        <div className="text-xs text-muted-foreground">
+                        <div
+                          className="text-xs text-muted-foreground truncate"
+                          title={`${deviceInfo}${hasLocation ? ` - ${locationParts.join(', ')}` : ''}`}
+                        >
                           {deviceInfo}
                           {hasLocation ? (
                             ` - ${locationParts.join(', ')}`
@@ -277,44 +282,48 @@ export function ViewSessionsTable({ views, totalCount, loading, currentPage, onP
                           )}
                         </div>
                       </TableCell>
-                      <TableCell>{view.share_link_name || t('links.untitledLink')}</TableCell>
+                      <TableCell className="min-w-[130px] max-w-[180px]">
+                        <div className="truncate" title={view.share_link_name || t('links.untitledLink')}>
+                          {view.share_link_name || t('links.untitledLink')}
+                        </div>
+                      </TableCell>
                       {isDashboardWidget && (
-                        <TableCell>
+                        <TableCell className="min-w-[150px] max-w-[220px]">
                           {view.document_id ? (
                             <Link
                               to={`/documents/${view.document_id}`}
-                              className="inline-flex items-center gap-1.5 truncate hover:underline"
+                              className="inline-flex items-center gap-1.5 max-w-full hover:underline"
                               title={view.document_name}
                             >
-                              <FileTypeIcon type={view.document_type} className="h-4 w-4" />
-                              <span>{view.document_name}</span>
+                              <FileTypeIcon type={view.document_type} className="h-4 w-4 shrink-0" />
+                              <span className="truncate">{view.document_name}</span>
                             </Link>
                           ) : view.dataroom_id ? (
                             <Link
                               to={`/datarooms/${view.dataroom_id}`}
-                              className="inline-flex items-center gap-1.5 truncate hover:underline"
+                              className="inline-flex items-center gap-1.5 max-w-full hover:underline"
                               title={view.dataroom_name}
                             >
-                              <FolderIcon className="h-4 w-4 text-blue-500" />
-                              <span>{view.dataroom_name}</span>
+                              <FolderIcon className="h-4 w-4 text-blue-500 shrink-0" />
+                              <span className="truncate">{view.dataroom_name}</span>
                             </Link>
                           ) : (
                             <span className="text-gray-400">—</span>
                           )}
                         </TableCell>
                       )}
-                      <TableCell>
+                      <TableCell className="w-36 whitespace-nowrap text-muted-foreground">
                         {formatDate(view.viewed_at, 'PP p')}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="w-36 whitespace-nowrap text-muted-foreground">
                         {view.downloaded_at
                           ? formatDate(view.downloaded_at, 'PP p')
                           : '—'}
                       </TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className="w-24 text-right whitespace-nowrap">
                         {formatDuration(view.duration_seconds)}
                       </TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className="w-24 text-right whitespace-nowrap">
                         {hasDataroomVisits ? '—' : `${(view.completion_rate * 100).toFixed(0)}%`}
                       </TableCell>
                     </TableRow>

--- a/frontend/src/pages/AdminDataroomsPage.jsx
+++ b/frontend/src/pages/AdminDataroomsPage.jsx
@@ -37,6 +37,7 @@ import { Progress } from '../components/ui/Progress';
 import { Pagination } from '../components/ui/Pagination';
 import { formatBytes } from '../lib/formatters';
 import { formatDate, formatRelativeTime, getAvatarInitial } from '../utils/formatters';
+import { cn } from '../lib/utils';
 import {
   getAdminDatarooms,
   deleteAdminDataroom,
@@ -184,17 +185,17 @@ export function AdminDataroomsPage() {
     }
   };
 
-  const renderSortableHeader = (field, label) => {
+  const renderSortableHeader = (field, label, className = '') => {
     const isActive = sortField === field;
     return (
-      <th className="p-4">
+      <th className={cn('p-4 whitespace-nowrap', className)}>
         <button
           type="button"
           onClick={() => handleSort(field)}
-          className="inline-flex items-center gap-1.5 font-semibold text-muted-foreground uppercase text-xs hover:text-foreground transition-colors group focus:outline-none"
+          className="inline-flex items-center gap-1.5 font-semibold text-muted-foreground uppercase text-xs hover:text-foreground transition-colors group focus:outline-none whitespace-nowrap"
         >
-          <span>{label}</span>
-          <span className="flex items-center">
+          <span className="whitespace-nowrap">{label}</span>
+          <span className="flex items-center shrink-0">
             {isActive ? (
               sortDirection === 'asc' ? (
                 <ArrowUp className="h-3.5 w-3.5 text-primary" />
@@ -314,41 +315,41 @@ export function AdminDataroomsPage() {
         {/* Governance Table */}
         <div className="rounded-xl border bg-card overflow-hidden shadow-xs">
           <div className="overflow-x-auto">
-            <table className="w-full text-left text-sm">
+            <table className="w-full min-w-[1000px] text-left text-sm">
               <thead className="border-b bg-muted/40 text-xs font-semibold text-muted-foreground uppercase">
                 <tr>
-                  {renderSortableHeader('name', t('admin.columnDataroomName'))}
-                  {renderSortableHeader('owner', t('admin.columnOwner'))}
-                  {renderSortableHeader('collaborators', t('admin.columnCollaborators'))}
-                  {renderSortableHeader('active_links', t('admin.columnActiveLinks'))}
-                  {renderSortableHeader('last_viewed', t('admin.columnLastViewed'))}
-                  {renderSortableHeader('storage', t('admin.columnStorageQuota'))}
-                  {renderSortableHeader('created', t('admin.columnCreated'))}
-                  <th className="p-4 text-right">{t('common.actions')}</th>
+                  {renderSortableHeader('name', t('admin.columnDataroomName'), 'min-w-[220px]')}
+                  {renderSortableHeader('owner', t('admin.columnOwner'), 'w-48')}
+                  {renderSortableHeader('collaborators', t('admin.columnCollaborators'), 'w-36')}
+                  {renderSortableHeader('active_links', t('admin.columnActiveLinks'), 'w-32')}
+                  {renderSortableHeader('last_viewed', t('admin.columnLastViewed'), 'w-32')}
+                  {renderSortableHeader('storage', t('admin.columnStorageQuota'), 'w-40')}
+                  {renderSortableHeader('created', t('admin.columnCreated'), 'w-32')}
+                  <th className="p-4 text-right whitespace-nowrap w-20">{t('common.actions')}</th>
                 </tr>
               </thead>
               <tbody className="divide-y">
                 {isLoading ? (
                   Array.from({ length: 5 }).map((_, i) => (
                     <tr key={i} className="animate-pulse">
-                      <td className="p-4">
+                      <td className="p-4 min-w-[220px]">
                         <div className="space-y-2">
                           <Skeleton className="h-4 w-40" />
                           <Skeleton className="h-3 w-16" />
                         </div>
                       </td>
-                      <td className="p-4">
+                      <td className="p-4 w-48">
                         <div className="flex items-center gap-2">
                           <Skeleton className="h-7 w-7 rounded-full" />
                           <Skeleton className="h-4 w-28" />
                         </div>
                       </td>
-                      <td className="p-4"><Skeleton className="h-4 w-12" /></td>
-                      <td className="p-4"><Skeleton className="h-4 w-10" /></td>
-                      <td className="p-4"><Skeleton className="h-4 w-20" /></td>
-                      <td className="p-4"><Skeleton className="h-4 w-32" /></td>
-                      <td className="p-4"><Skeleton className="h-4 w-20" /></td>
-                      <td className="p-4 text-right"><Skeleton className="h-8 w-8 ml-auto rounded-md" /></td>
+                      <td className="p-4 w-36"><Skeleton className="h-4 w-12" /></td>
+                      <td className="p-4 w-32"><Skeleton className="h-4 w-10" /></td>
+                      <td className="p-4 w-32"><Skeleton className="h-4 w-20" /></td>
+                      <td className="p-4 w-40"><Skeleton className="h-4 w-32" /></td>
+                      <td className="p-4 w-32"><Skeleton className="h-4 w-20" /></td>
+                      <td className="p-4 text-right w-20"><Skeleton className="h-8 w-8 ml-auto rounded-md" /></td>
                     </tr>
                   ))
                 ) : datarooms.length === 0 ? (
@@ -379,21 +380,21 @@ export function AdminDataroomsPage() {
                     }
 
                     return (
-                      <tr key={dataroom.id} className="hover:bg-muted/30 transition-colors">
+                      <tr key={dataroom.id} className="hover:bg-muted/30 transition-colors border-b">
                         {/* Name + Storage Version Badge */}
-                        <td className="p-4">
+                        <td className="p-4 min-w-[220px] max-w-[280px]">
                           <div className="flex items-start gap-3">
                             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary mt-0.5">
                               <Folder className="h-4 w-4" />
                             </div>
-                            <div className="space-y-1 min-w-0">
+                            <div className="space-y-1 min-w-0 flex-1">
                               <Link
                                 to={`/datarooms/${dataroom.id}`}
-                                className="font-semibold text-foreground hover:text-primary transition-colors flex items-center gap-1.5 truncate group"
+                                className="font-semibold text-foreground hover:text-primary transition-colors flex items-center gap-1.5 group"
                                 title={dataroom.name}
                               >
-                                <span>{dataroom.name}</span>
-                                <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground" />
+                                <span className="truncate">{dataroom.name}</span>
+                                <ExternalLink className="h-3 w-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground" />
                               </Link>
                               {isLegacyV1 && (
                                 <div className="flex items-center gap-1.5">
@@ -408,21 +409,21 @@ export function AdminDataroomsPage() {
                         </td>
 
                         {/* Owner */}
-                        <td className="p-4">
+                        <td className="p-4 w-48">
                           {dataroom.owner ? (
                             <div className="flex items-center gap-2.5">
-                              <Avatar className="h-7 w-7 rounded-full border">
+                              <Avatar className="h-7 w-7 rounded-full border shrink-0">
                                 {dataroom.owner.avatar_url && <AvatarImage src={dataroom.owner.avatar_url} />}
                                 <AvatarFallback className="text-[10px]">
                                   {getAvatarInitial(dataroom.owner.name, dataroom.owner.email)}
                                 </AvatarFallback>
                               </Avatar>
                               <div className="min-w-0 text-xs">
-                                <p className="font-medium text-foreground truncate max-w-[140px]">
+                                <p className="font-medium text-foreground truncate max-w-[130px]" title={dataroom.owner.name || dataroom.owner.email}>
                                   {dataroom.owner.name || dataroom.owner.email}
                                 </p>
                                 {dataroom.owner.name && (
-                                  <p className="text-muted-foreground truncate max-w-[140px]">{dataroom.owner.email}</p>
+                                  <p className="text-muted-foreground truncate max-w-[130px]" title={dataroom.owner.email}>{dataroom.owner.email}</p>
                                 )}
                               </div>
                             </div>
@@ -432,13 +433,13 @@ export function AdminDataroomsPage() {
                         </td>
 
                         {/* Collaborators */}
-                        <td className="p-4">
+                        <td className="p-4 w-36 whitespace-nowrap">
                           <button
                             type="button"
                             onClick={() => setDataroomForCollaborators(dataroom)}
-                            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-muted/60 hover:bg-muted text-foreground transition-colors cursor-pointer border"
+                            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-muted/60 hover:bg-muted text-foreground transition-colors cursor-pointer border whitespace-nowrap"
                           >
-                            <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                            <Users className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                             <span>{dataroom.collaborator_count || 0}</span>
                             <span className="text-muted-foreground text-[11px] ml-0.5">
                               {t('admin.manage')}
@@ -447,15 +448,15 @@ export function AdminDataroomsPage() {
                         </td>
 
                         {/* Active Links */}
-                        <td className="p-4">
-                          <div className="flex items-center gap-1.5 text-xs font-medium text-foreground">
-                            <Link2 className="h-3.5 w-3.5 text-blue-500" />
+                        <td className="p-4 w-32 whitespace-nowrap">
+                          <div className="flex items-center gap-1.5 text-xs font-medium text-foreground whitespace-nowrap">
+                            <Link2 className="h-3.5 w-3.5 text-blue-500 shrink-0" />
                             <span>{dataroom.active_links_count || 0}</span>
                           </div>
                         </td>
 
                         {/* Last Viewed */}
-                        <td className="p-4 text-xs text-muted-foreground whitespace-nowrap">
+                        <td className="p-4 text-xs text-muted-foreground whitespace-nowrap w-32">
                           {dataroom.last_viewed_at ? (
                             <span title={formatDate(dataroom.last_viewed_at, 'PPpp')}>
                               {formatRelativeTime(dataroom.last_viewed_at)}
@@ -466,7 +467,7 @@ export function AdminDataroomsPage() {
                         </td>
 
                         {/* Storage / Quota Progress */}
-                        <td className="p-4">
+                        <td className="p-4 w-40">
                           <div className="flex flex-col gap-1 w-36">
                             <div className="flex justify-between text-xs font-medium">
                               <span className="text-foreground">{formatBytes(usedBytes)}</span>
@@ -480,7 +481,7 @@ export function AdminDataroomsPage() {
                               indicatorClassName={indicatorColor}
                             />
                             {quotaMb > 0 && (
-                              <span className="text-[10px] text-muted-foreground">
+                              <span className="text-[10px] text-muted-foreground whitespace-nowrap">
                                 {usagePercentage.toFixed(0)}% {t('admin.used')}
                               </span>
                             )}
@@ -488,12 +489,12 @@ export function AdminDataroomsPage() {
                         </td>
 
                         {/* Created Date */}
-                        <td className="p-4 text-xs text-muted-foreground">
+                        <td className="p-4 text-xs text-muted-foreground whitespace-nowrap w-32">
                           {formatDate(dataroom.created_at, 'PP')}
                         </td>
 
                         {/* Actions Menu */}
-                        <td className="p-4 text-right">
+                        <td className="p-4 text-right w-20">
                           <DropdownMenu.Root>
                             <DropdownMenu.Trigger asChild>
                               <Button

--- a/frontend/src/pages/AdminUsersPage.jsx
+++ b/frontend/src/pages/AdminUsersPage.jsx
@@ -28,6 +28,7 @@ import { Select } from '../components/ui/Select';
 import { Progress } from '../components/ui/Progress';
 import { Pagination } from '../components/ui/Pagination';
 import { formatBytes } from '../lib/formatters';
+import { cn } from '../lib/utils';
 
 function AddUserForm({ onAddUser, onCancel }) {
   const { t } = useTranslation();
@@ -180,25 +181,25 @@ function AddUserForm({ onAddUser, onCancel }) {
 function SkeletonRow() {
   return (
     <tr className="border-b">
-      <td className="p-4">
-        <Skeleton className="h-4 w-32" />
+      <td className="p-4 min-w-[160px]">
+        <Skeleton className="h-4 w-28" />
       </td>
-      <td className="p-4">
-        <Skeleton className="h-4 w-48" />
+      <td className="p-4 min-w-[200px]">
+        <Skeleton className="h-4 w-40" />
       </td>
-      <td className="p-4">
-        <Skeleton className="h-4 w-20" />
+      <td className="p-4 w-28">
+        <Skeleton className="h-4 w-16" />
       </td>
-      <td className="p-4">
-        <Skeleton className="h-4 w-20" />
+      <td className="p-4 w-24">
+        <Skeleton className="h-4 w-16" />
       </td>
-      <td className="p-4">
+      <td className="p-4 w-36">
         <Skeleton className="h-4 w-24" />
       </td>
-      <td className="p-4">
-        <Skeleton className="h-4 w-24" />
+      <td className="p-4 w-32">
+        <Skeleton className="h-4 w-20" />
       </td>
-      <td className="p-4 text-right">
+      <td className="p-4 text-right w-24">
         <Skeleton className="h-8 w-16 ml-auto rounded-md" />
       </td>
     </tr>
@@ -460,17 +461,17 @@ export function AdminUsersPage() {
     }
   };
 
-  const renderSortableHeader = (field, label) => {
+  const renderSortableHeader = (field, label, className = '') => {
     const isActive = sortField === field;
     return (
-      <th className="p-4">
+      <th className={cn('p-4 whitespace-nowrap', className)}>
         <button
           type="button"
           onClick={() => handleSort(field)}
-          className="inline-flex items-center gap-1.5 font-semibold text-muted-foreground uppercase text-xs hover:text-foreground transition-colors group focus:outline-none"
+          className="inline-flex items-center gap-1.5 font-semibold text-muted-foreground uppercase text-xs hover:text-foreground transition-colors group focus:outline-none whitespace-nowrap"
         >
-          <span>{label}</span>
-          <span className="flex items-center">
+          <span className="whitespace-nowrap">{label}</span>
+          <span className="flex items-center shrink-0">
             {isActive ? (
               sortDirection === 'asc' ? (
                 <ArrowUp className="h-3.5 w-3.5 text-primary" />
@@ -606,16 +607,16 @@ export function AdminUsersPage() {
       {/* Users Table */}
       <div className="rounded-xl border bg-card overflow-hidden shadow-xs">
         <div className="overflow-x-auto">
-          <table className="w-full text-left text-sm">
+          <table className="w-full min-w-[850px] text-left text-sm">
             <thead className="border-b bg-muted/40 text-xs font-semibold text-muted-foreground uppercase">
               <tr>
-                {renderSortableHeader('name', t('analytics.name'))}
-                <th className="p-4 font-semibold text-muted-foreground uppercase text-xs">{t('settings.email')}</th>
-                {renderSortableHeader('role', t('admin.role'))}
-                {renderSortableHeader('status', t('common.status'))}
-                {renderSortableHeader('storage', t('admin.storageQuota'))}
-                {renderSortableHeader('created', t('admin.joinedDateColumn'))}
-                <th className="p-4 text-right font-semibold text-muted-foreground uppercase text-xs">{t('common.actions')}</th>
+                {renderSortableHeader('name', t('analytics.name'), 'min-w-[160px]')}
+                <th className="p-4 font-semibold text-muted-foreground uppercase text-xs whitespace-nowrap min-w-[200px]">{t('settings.email')}</th>
+                {renderSortableHeader('role', t('admin.role'), 'w-28')}
+                {renderSortableHeader('status', t('common.status'), 'w-24')}
+                {renderSortableHeader('storage', t('admin.storageQuota'), 'w-36')}
+                {renderSortableHeader('created', t('admin.joinedDateColumn'), 'w-32')}
+                <th className="p-4 text-right font-semibold text-muted-foreground uppercase text-xs whitespace-nowrap w-24">{t('common.actions')}</th>
               </tr>
             </thead>
             <tbody className="divide-y">
@@ -650,40 +651,43 @@ export function AdminUsersPage() {
                 users.map((user) =>
                   editingUserId === user.id ? (
                     <tr key={user.id} className="border-b bg-muted/50">
-                      <td className="p-4 font-medium">
+                      <td className="p-4 font-medium min-w-[160px]">
                         <Input
                           name="name"
                           value={editedUserData.name}
                           onChange={handleEditDataChange}
                           disabled={savingUserId === user.id}
+                          className="w-full max-w-[180px]"
                         />
                       </td>
-                      <td className="p-4 text-muted-foreground">
+                      <td className="p-4 text-muted-foreground min-w-[200px] max-w-[260px] truncate" title={user.email}>
                         {user.email}
                       </td>
-                      <td className="p-4 text-muted-foreground">
+                      <td className="p-4 text-muted-foreground w-28">
                         <Select
                           name="role"
                           value={editedUserData.role}
                           onChange={handleEditDataChange}
                           disabled={savingUserId === user.id}
+                          className="w-full"
                         >
                           <option value="member">{t('admin.roleMember')}</option>
                           <option value="admin">{t('admin.roleAdmin')}</option>
                         </Select>
                       </td>
-                      <td className="p-4 text-muted-foreground">
+                      <td className="p-4 text-muted-foreground w-24">
                         <Select
                           name="is_active"
                           value={editedUserData.is_active}
                           onChange={handleEditDataChange}
                           disabled={savingUserId === user.id}
+                          className="w-full"
                         >
                           <option value={true}>{t('common.active')}</option>
                           <option value={false}>{t('common.inactive')}</option>
                         </Select>
                       </td>
-                      <td className="p-4">
+                      <td className="p-4 w-36">
                         <div className="flex items-center gap-1.5">
                           <Input
                             name="custom_file_size_quota_mb"
@@ -691,17 +695,17 @@ export function AdminUsersPage() {
                             placeholder={t('common.default')}
                             value={editedUserData.custom_file_size_quota_mb ?? ''}
                             onChange={handleEditDataChange}
-                            className="w-24 text-sm"
+                            className="w-20 text-sm"
                             disabled={savingUserId === user.id}
                             min="0"
                           />
                           <span className="text-xs text-muted-foreground">MB</span>
                         </div>
                       </td>
-                      <td className="p-4 text-muted-foreground">
+                      <td className="p-4 text-muted-foreground whitespace-nowrap w-32">
                         {new Date(user.date_joined).toLocaleDateString()}
                       </td>
-                      <td className="p-4 text-right">
+                      <td className="p-4 text-right w-24">
                         <div className="flex items-center justify-end gap-x-2">
                           <Button
                             variant="ghost"
@@ -730,20 +734,20 @@ export function AdminUsersPage() {
                     </tr>
                   ) : (
                     <tr key={user.id} className="border-b">
-                      <td className="p-4 font-medium">
-                        <Link to={`/admin/users/${user.id}`} className="hover:underline">
+                      <td className="p-4 font-medium min-w-[160px] max-w-[200px]">
+                        <Link to={`/admin/users/${user.id}`} className="hover:underline block truncate" title={user.name || t('common.unnamed')}>
                           {user.name || t('common.unnamed')}
                         </Link>
                       </td>
-                      <td className="p-4 text-muted-foreground">
-                        <Link to={`/admin/users/${user.id}`} className="hover:underline text-muted-foreground">
+                      <td className="p-4 text-muted-foreground min-w-[200px] max-w-[260px]">
+                        <Link to={`/admin/users/${user.id}`} className="hover:underline text-muted-foreground block truncate" title={user.email}>
                           {user.email}
                         </Link>
                       </td>
-                      <td className="p-4 text-muted-foreground capitalize">
+                      <td className="p-4 text-muted-foreground capitalize w-28 whitespace-nowrap">
                         {user.role === 'admin' ? t('admin.roleAdmin') : user.role === 'member' ? t('admin.roleMember') : user.role}
                       </td>
-                      <td className="p-4">
+                      <td className="p-4 w-24 whitespace-nowrap">
                         <span
                           className={`rounded-full px-2 py-1 text-xs font-medium ${
                             user.is_active
@@ -754,13 +758,13 @@ export function AdminUsersPage() {
                           {user.is_active ? t('common.active') : t('common.inactive')}
                         </span>
                       </td>
-                      <td className="p-4">
+                      <td className="p-4 w-36">
                         <UserStorageUsage user={user} />
                       </td>
-                      <td className="p-4 text-muted-foreground">
+                      <td className="p-4 text-muted-foreground whitespace-nowrap w-32">
                         {new Date(user.date_joined).toLocaleDateString()}
                       </td>
-                      <td className="p-4 text-right">
+                      <td className="p-4 text-right w-24">
                         <div className="flex items-center justify-end gap-x-2">
                           <Button
                             variant="ghost"


### PR DESCRIPTION
…n widths

- Fix column squeeze and header text wrapping in AdminUsersPage, AdminDataroomsPage, LinksTable, and ViewSessionsTable.
- Add whitespace-nowrap and shrink-0 to sortable and static table headers to prevent multi-word titles from breaking lines.
- Enforce min/max width constraints and text truncation on primary content columns (Name, Link, Document, Visitor).
- Assign fixed widths to secondary numeric and action columns (Role, Status, Storage, Visits, Created, Viewed At, Actions).
- Add min-w safeguards to tables to enable horizontal scrolling on narrow viewports without crushing table layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved table layouts across document links, view sessions, datarooms, and users pages.
  - Added responsive column sizing to reduce layout shifts and preserve readable alignment.
  - Long links, names, emails, and device details now truncate cleanly with tooltips where applicable.
  - Prevented unwanted text wrapping and standardized widths for dates, actions, controls, and other table columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->